### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -843,7 +843,7 @@ function filterTasks(searchTerm) {
             const textSpan = el.querySelector('.task-text');
             if (textSpan) {
                 // Remove highlights
-                textSpan.innerHTML = textSpan.textContent;
+                textSpan.textContent = textSpan.textContent;
             }
         });
         return;
@@ -865,7 +865,7 @@ function filterTasks(searchTerm) {
         } else {
             el.style.display = 'none';
             // Remove highlights
-            textSpan.innerHTML = textSpan.textContent;
+            textSpan.textContent = textSpan.textContent;
         }
     });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/S540d/Eisenhauer/security/code-scanning/3](https://github.com/S540d/Eisenhauer/security/code-scanning/3)

To fix the problem, ensure that whenever you assign to `innerHTML`, any string is safely encoded and cannot result in the browser interpreting text as markup. In this case, you should set `textSpan.textContent` when removing highlights instead of setting `innerHTML = textSpan.textContent`. That is, outside of the highlighting branch, revert to using `.textContent` assignment. Specifically, change:

```js
textSpan.innerHTML = textSpan.textContent;
```

to:

```js
textSpan.textContent = textSpan.textContent;
```

This maintains safety: any text un-highlighting will use `.textContent`, which inherently encodes the value safely and does not introduce possible XSS conditions.  
Regions to change:  
- Replace all instances of `textSpan.innerHTML = textSpan.textContent;` with `textSpan.textContent = textSpan.textContent;` (lines 846 and 868).

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
