### PR TITLE
Fix: About button not working after theme switch

### DIFF
--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -375,6 +375,34 @@ export function openSettingsModal(
     }
   });
 
+  // Setup theme button event listeners (re-register on each modal open to ensure consistency)
+  themeButtons.forEach((btn) => {
+    const newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+
+    newBtn.addEventListener('click', () => {
+      const theme = newBtn.dataset.theme;
+
+      // Update active state
+      document.querySelectorAll('.theme-btn').forEach((b) => b.classList.remove('active'));
+      newBtn.classList.add('active');
+
+      // Update theme
+      if (theme === 'dark') {
+        localStorage.setItem('darkMode', 'true');
+        document.body.classList.add('dark-mode');
+      } else if (theme === 'system') {
+        localStorage.removeItem('darkMode');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (prefersDark) {
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove('dark-mode');
+        }
+      }
+    });
+  });
+
   // Update language toggle button active state - use currentLanguage parameter
   const langButtons = document.querySelectorAll('.lang-btn');
 

--- a/script.js
+++ b/script.js
@@ -412,52 +412,8 @@ function setupEventListeners() {
     cancelBtn.addEventListener('click', closeModal);
   }
 
-  // Settings modal close
-  const settingsCancelBtn = document.getElementById('settingsCancelBtn');
-  if (settingsCancelBtn) {
-    settingsCancelBtn.addEventListener('click', () => {
-      document.getElementById('settingsModal').style.display = 'none';
-    });
-  }
-
-  // Theme toggle buttons in settings modal
-  const themeButtons = document.querySelectorAll('.theme-btn');
-  const currentTheme = localStorage.getItem(STORAGE_KEYS.DARK_MODE);
-
-  // Set initial active button
-  themeButtons.forEach((btn) => {
-    const theme = btn.dataset.theme;
-    if (
-      (theme === 'dark' && currentTheme === 'true') ||
-      (theme === 'system' && currentTheme === null)
-    ) {
-      btn.classList.add('active');
-    }
-  });
-
-  themeButtons.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const theme = btn.dataset.theme;
-
-      // Update active state
-      themeButtons.forEach((b) => b.classList.remove('active'));
-      btn.classList.add('active');
-
-      // Update theme
-      if (theme === 'dark') {
-        localStorage.setItem(STORAGE_KEYS.DARK_MODE, 'true');
-        document.body.classList.add('dark-mode');
-      } else if (theme === 'system') {
-        localStorage.removeItem(STORAGE_KEYS.DARK_MODE);
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (prefersDark) {
-          document.body.classList.add('dark-mode');
-        } else {
-          document.body.classList.remove('dark-mode');
-        }
-      }
-    });
-  });
+  // NOTE: Settings modal close and theme toggle buttons are now handled in ui.js openSettingsModal()
+  // to ensure event listeners are properly registered on each modal open
 
   // Language toggle buttons in settings modal
   const langButtons = document.querySelectorAll('.lang-btn');


### PR DESCRIPTION
## 🐛 Problem

Nach dem Wechsel der Appearance-Einstellung (Dark/System) funktionierte der **About-Button** nicht mehr.

## 🔍 Root Cause

Die Theme-Button Event-Listener wurden nur einmal beim **DOMContentLoaded** in `script.js` registriert, während der About-Button bei jedem **openSettingsModal()** in `ui.js` neu registriert wurde.

Dies führte zu inkonsistentem Verhalten:
- Theme-Buttons hatten statische Listener (DOMContentLoaded)
- About-Button wurde dynamisch re-registriert (bei jedem Modal-Öffnen)
- Nach Theme-Wechsel verlor About-Button wahrscheinlich seinen Listener durch DOM-Manipulationen

## ✅ Lösung

**Alle interaktiven Elemente im Settings-Modal werden jetzt konsistent in `openSettingsModal()` registriert:**

1. **Theme-Button Event-Listener verschoben:**
   - Von: `script.js` DOMContentLoaded
   - Nach: `ui.js` openSettingsModal()

2. **Event-Listener Re-Registration:**
   - Theme-Buttons bekommen ihre Listener bei jedem Modal-Öffnen neu
   - Konsistent mit About-Button, Sign-Out-Button, Settings-Close-Button

3. **Code-Bereinigung:**
   - Entfernung duplizierter Theme-Button-Registrierung aus `script.js`
   - Alle Modal-Buttons folgen jetzt demselben Pattern

## 📝 Änderungen

### `js/modules/ui.js`
- Theme-Button Event-Listener hinzugefügt zu `openSettingsModal()`
- Verwendet Clone-Pattern wie andere Buttons im Modal

### `script.js`
- Entfernte Theme-Button Registrierung aus DOMContentLoaded
- Kommentar hinzugefügt, der auf neue Location hinweist

## 🧪 Testing

**Reproduktion (vor Fix):**
1. Öffne Settings
2. Klicke About → Modal öffnet ✓
3. Schließe About-Modal
4. Wechsle Appearance (Dark ↔ System)
5. Klicke About → **Nichts passiert** ✗

**Nach Fix:**
1. Öffne Settings
2. Klicke About → Modal öffnet ✓
3. Schließe About-Modal
4. Wechsle Appearance (Dark ↔ System)
5. Klicke About → **Modal öffnet** ✓

**Zusätzliche Tests:**
- [ ] Theme-Wechsel funktioniert weiterhin
- [ ] About-Button funktioniert nach mehreren Theme-Wechseln
- [ ] Sign-Out-Button funktioniert
- [ ] Settings-Close-Button funktioniert
- [ ] Keine Regressionen in anderen Bereichen

## 🔧 Technische Details

**Pattern für Modal-Buttons:**
```javascript
// Remove old listener by cloning
const newBtn = btn.cloneNode(true);
btn.parentNode.replaceChild(newBtn, btn);

// Add new listener
newBtn.addEventListener('click', () => { ... });
```

Dieses Pattern wird jetzt konsistent für alle Buttons im Settings-Modal verwendet.

---

Fixes #105 (part 2 - About button issue)