### PR TITLE
chore: Sync Android version to 1.8.3 (versionCode 14)

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 35
-        versionCode 13
-        versionName "1.8.2"  // Match PWA version
+        versionCode 14
+        versionName "1.8.3"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Update Android build.gradle to match PWA version (1.8.3)
- Increment versionCode from 13 to 14 for Play Store

This enables the build-android.yml workflow to create the Play Store release artifact.

🤖 Generated with Claude Code