### PR TITLE
fix: Apply PR #138 Copilot review suggestions

### DIFF
--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -278,21 +278,14 @@ export function moveTask(taskId, fromSegment, toSegment, saveCallback = null) {
 }
 
 /**
-<<<<<<< HEAD
- * Reorder task within the same segment
- * @param {number} taskId - Task ID to reorder
- * @param {number} segment - Segment ID
- * @param {number} newIndex - New index position
- * @returns {object|null} The reordered task or null if not found
-=======
  * Reorder task within same segment (for drag & drop sorting)
- * @param {string} taskId - Task ID
+ * @param {number} taskId - Task ID
  * @param {number} segment - Segment ID
  * @param {number} newIndex - New position index in the segment
+ * @param {function} saveCallback - Optional callback to save changes
  * @returns {object|null} Reordered task or null if not found
->>>>>>> 6d61f7edf82db96bddb0e94956ef3783336a5f02
  */
-export function reorderTask(taskId, segment, newIndex) {
+export function reorderTask(taskId, segment, newIndex, saveCallback = null) {
   // Input validation
   if (!Number.isInteger(segment) || segment < 1 || segment > 5) {
     throw new RangeError('Segment ID must be an integer between 1 and 5');
@@ -316,6 +309,11 @@ export function reorderTask(taskId, segment, newIndex) {
   // Insert at new position
   const safeIndex = Math.min(newIndex, tasks[segment].length);
   tasks[segment].splice(safeIndex, 0, task);
+
+  // Call save callback if provided
+  if (saveCallback) {
+    saveCallback(task);
+  }
 
   return task;
 }

--- a/script.js
+++ b/script.js
@@ -323,13 +323,8 @@ function handleReorderTask(taskId, segment, direction) {
   // Don't do anything if index didn't change
   if (newIndex === currentIndex) return;
 
-  // Reorder using existing reorderTask function
-  const reorderedTask = reorderTask(taskId, segment, newIndex);
-
-  if (reorderedTask) {
-    // Re-render
-    renderTasksWithCallbacks();
-
+  // Reorder using existing reorderTask function with save callback
+  const reorderedTask = reorderTask(taskId, segment, newIndex, () => {
     // Save to storage based on mode
     if (currentUser && db && !isGuestMode) {
       // In authenticated mode, save all tasks in the segment
@@ -339,6 +334,11 @@ function handleReorderTask(taskId, segment, direction) {
       // Save to LocalForage (guest mode)
       saveGuestTasks(tasks);
     }
+  });
+
+  if (reorderedTask) {
+    // Re-render
+    renderTasksWithCallbacks();
   }
 }
 


### PR DESCRIPTION
## Summary
Addresses remaining Copilot review suggestions from PR #138:

**Fixed:**
- ✅ Correct JSDoc type for `taskId` parameter (`{number}` instead of `{string}`)
- ✅ Add `saveCallback` parameter to `reorderTask()` for persistence
- ✅ Update `handleReorderTask()` to pass saveCallback
- ✅ Resolve merge conflict markers in tasks.js

**Changes:**
- [tasks.js](js/modules/tasks.js:280-324) - Fixed JSDoc, added saveCallback parameter, calls saveCallback after reordering
- [script.js](script.js:326-343) - Updated handleReorderTask to pass saveCallback

**Deferred:**
- ⚠️  Unit tests for `reorderTask()` - will be added in separate testing PR

## References
- PR #138 Copilot review comments
- Related: PR #137, #139

## Test Plan
- [x] Manual testing: Reorder buttons work and persist changes
- [x] Verified saveCallback is called after reordering
- [x] Works in both guest mode (LocalForage) and authenticated mode (Firestore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)