### PR TITLE
fix: Disable environment toggle in personalization settings

### DIFF
--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -690,19 +690,15 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     currentEnv = 'staging';
   }
 
-  // If we're on the testing environment, hide the environment switcher entirely
-  if (isTestingEnv) {
-    envButtons.forEach((btn) => {
-      btn.style.display = 'none';
-    });
-  } else {
-    envButtons.forEach((btn) => {
-      btn.classList.remove('active');
-      if (btn.dataset.env === currentEnv) {
-        btn.classList.add('active');
-      }
-    });
-  }
+  // Disable all environment buttons (keep them visible but non-functional)
+  envButtons.forEach((btn) => {
+    btn.classList.remove('active');
+    if (btn.dataset.env === currentEnv) {
+      btn.classList.add('active');
+    }
+    // Disable the button to make it non-functional
+    btn.disabled = true;
+  });
 
   // Show/hide environment warning based on current environment
   const envWarning = document.getElementById('personalizeEnvWarning');
@@ -769,19 +765,7 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     // Handle environment button clicks
     const envBtn = target.closest('.env-btn');
     if (envBtn) {
-      const targetEnv = envBtn.dataset.env;
-      const pathname = window.location && window.location.pathname ? window.location.pathname : '';
-      const currentEnv = pathname.includes('/staging/') ? 'staging' : 'production';
-
-      // Don't do anything if clicking the already active environment
-      if (targetEnv === currentEnv) {
-        return;
-      }
-
-      // Trigger environment switch (will be handled by script.js)
-      if (window.switchEnvironment) {
-        window.switchEnvironment(targetEnv, currentLanguage);
-      }
+      // Environment switching is disabled - do nothing
       return;
     }
 

--- a/style.css
+++ b/style.css
@@ -2256,6 +2256,11 @@ body.dark-mode .lang-btn.active {
   color: white;
 }
 
+.env-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 body.dark-mode .env-btn {
   background-color: rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
## Summary
- Deaktiviert die Umgebungswechsel-Funktion (Production/Staging/Beta) in Einstellungen > Personalisieren
- Die Environment-Buttons bleiben sichtbar zur Anzeige der aktuellen Umgebung, sind aber nicht mehr klickbar

## Changes
- Environment-Buttons (`.env-btn`) werden als `disabled` gesetzt
- Click-Handler für Environment-Switching gibt sofort `return` zurück
- CSS-Regel für `:disabled` Zustand hinzugefügt (opacity 0.5, cursor not-allowed)
- Entfernt die bedingte Logik zum Verstecken der Buttons in der testing-Umgebung

## Test plan
- [ ] Einstellungen > Personalisieren öffnen
- [ ] Alle Environment-Buttons sollten sichtbar aber ausgegraut sein
- [ ] Klick auf Environment-Buttons sollte keine Aktion auslösen
- [ ] Aktuelles Environment sollte weiterhin korrekt angezeigt werden (active state)
- [ ] Cursor sollte als "not-allowed" angezeigt werden beim Hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)