### PR TITLE
docs: Update documentation for Epic #148

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -472,33 +472,39 @@ document.addEventListener('click', (e) => {
 
 ### Deployment Strategy
 
-**GitHub Actions Workflows:**
+**Unified GitHub Actions Workflow:**
+
+A single `deploy-unified.yml` handles all three environments with branch-based detection:
 
 ```yaml
-# .github/workflows/deploy.yml (main → production)
+# .github/workflows/deploy-unified.yml
 on:
   push:
-    branches: [main]
+    branches: [main, staging, testing]
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [auto, production, staging, testing]
 
 jobs:
   deploy:
-    - npm run build            # VITE_ENV=production
-    - Deploy to /              # Root of gh-pages
+    steps:
+      - name: Determine environment
+        # main → production (/)
+        # staging → staging (/staging/)
+        # testing → testing (/testing/)
 
-# .github/workflows/deploy-staging.yml
-on:
-  push:
-    branches: [staging]
+      - name: Build ${{ env }}
+        run: npm run ${{ build_script }}
 
-jobs:
-  deploy-staging:
-    - npm run build:staging    # VITE_ENV=staging
-    - Deploy to /staging/      # Subdirectory
+      - name: Deploy to GitHub Pages
+        # Uses peaceiris/actions-gh-pages@v3
 ```
 
 **Concurrency Control:**
 
-All three workflows use the same concurrency group to prevent race conditions:
+All deployments use the same concurrency group to prevent race conditions:
 
 ```yaml
 concurrency:
@@ -565,8 +571,8 @@ productFlavors {
         applicationId "com.sven4321.eisenhauer.staging"
         manifestPlaceholders = [defaultUrl: "https://...Eisenhauer/staging/"]
     }
-    testing {
-        applicationId "com.sven4321.eisenhauer.testing"
+    beta {  // Named 'beta' due to Android 'testing' keyword constraint
+        applicationId "com.sven4321.eisenhauer.beta"
         manifestPlaceholders = [defaultUrl: "https://...Eisenhauer/testing/"]
     }
 }
@@ -627,11 +633,17 @@ rollupOptions: {
 // Workbox configuration in vite.config.js
 workbox: {
   globPatterns: ['**/*.{js,css,html,png,svg,json}'],
-  cleanupOutdatedCaches: true
+  cleanupOutdatedCaches: true,
+  cacheId: `eisenhauer-${environment}`  // Environment-specific cache
 }
 ```
 
-**Cache naming:** Environment-specific (from #145)
+**Cache Isolation:** Each environment has its own cache namespace:
+- `eisenhauer-production`
+- `eisenhauer-staging`
+- `eisenhauer-testing`
+
+This prevents cache pollution when switching between environments.
 
 ---
 
@@ -681,6 +693,6 @@ The app is **WCAG 2.1 Level AA compliant**.
 
 ---
 
-**Version:** 1.9.2
-**Last Updated:** 2026-01-29
+**Version:** 1.10.0
+**Last Updated:** 2026-02-01
 **Maintainer:** S540d

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,7 +35,7 @@ The project supports three isolated environments:
 - **URL:** https://s540d.github.io/Eisenhauer/testing/
 - **Firebase Project:** `eisenhauer-testing`
 - **Branch:** `testing`
-- **Android App ID:** `com.sven4321.eisenhauer.testing`
+- **Android App ID:** `com.sven4321.eisenhauer.beta` (Flavor: `beta`)
 - **Build Command:** `npm run build:testing`
 
 ---
@@ -155,19 +155,19 @@ adb install app/build/outputs/apk/staging/release/app-staging-release.apk
 **App Name:** Eisenhauer (Staging)
 **Package:** `com.sven4321.eisenhauer.staging`
 
-#### Testing Build
+#### Testing/Beta Build
 
 ```bash
 cd android
-./gradlew assembleTestingRelease
+./gradlew assembleBetaRelease
 
 # Install on device
-adb install app/build/outputs/apk/testing/release/app-testing-release.apk
+adb install app/build/outputs/apk/beta/release/app-beta-release.apk
 ```
 
 **Opens:** https://s540d.github.io/Eisenhauer/testing/
-**App Name:** Eisenhauer (Testing)
-**Package:** `com.sven4321.eisenhauer.testing`
+**App Name:** Eisenhauer (Beta)
+**Package:** `com.sven4321.eisenhauer.beta`
 
 ### Side-by-Side Installation
 
@@ -176,17 +176,17 @@ All three apps can be installed simultaneously on one device due to different pa
 ```bash
 # Install all three
 cd android
-./gradlew assembleProdRelease assembleStagingRelease assembleTestingRelease
+./gradlew assembleProdRelease assembleStagingRelease assembleBetaRelease
 
 adb install app/build/outputs/apk/prod/release/app-prod-release.apk
 adb install app/build/outputs/apk/staging/release/app-staging-release.apk
-adb install app/build/outputs/apk/testing/release/app-testing-release.apk
+adb install app/build/outputs/apk/beta/release/app-beta-release.apk
 ```
 
 **Result:** Three separate app icons in launcher:
-- "Eisenhauer Matrix"
+- "Eisenhauer Matrix" (Production)
 - "Eisenhauer (Staging)"
-- "Eisenhauer (Testing)"
+- "Eisenhauer (Beta)" (Testing environment)
 
 ### Digital Asset Links Verification
 
@@ -378,6 +378,6 @@ This means Digital Asset Links verification failed.
 
 ---
 
-**Last Updated:** 2026-01-29
+**Last Updated:** 2026-02-01
 **Maintainer:** S540d
-**Version:** 1.9.2
+**Version:** 1.10.0


### PR DESCRIPTION
## Summary
Update TESTING.md and ARCHITECTURE.md to reflect changes from Epic #148.

## Changes

### TESTING.md
- Corrected Android flavor name from `testing` to `beta` (Android keyword constraint)
- Updated build commands (`assembleBetaRelease` instead of `assembleTestingRelease`)
- Updated package names in examples
- Updated version to 1.10.0

### ARCHITECTURE.md
- Documented unified `deploy-unified.yml` workflow (replaces 3 separate workflows)
- Added `cacheId` documentation for Service Worker cache isolation
- Updated Android build flavors section with `beta` flavor note
- Updated version to 1.10.0

## Refs
- Part of Epic #148
- Addresses Phase 6 of #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)