### PR TITLE
chore: Phase 5 — Version Bump 1.11.0

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 35
-        versionCode 20
-        versionName "1.10.2"  // Match PWA version
+        versionCode 21
+        versionName "1.11.0"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eisenhauer-matrix",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Eine moderne, mobile-first Progressive Web App zur Aufgabenverwaltung nach der Eisenhauer-Matrix-Methode.",
   "main": "index.html",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump to 1.11.0 / versionCode 21 (Phase 5 of #155)
- Marks completion of all major dependency updates

## Final State
| Metric | Result |
|--------|--------|
| npm audit | **0 vulnerabilities** |
| ESLint | 0 errors |
| Tests | 150 passing |
| Build | ✅ |

## Updated Versions
| Component | Version |
|-----------|---------|
| PWA | 1.11.0 |
| Android versionCode | 21 |
| Android versionName | 1.11.0 |
| Firebase | 12.9.0 |
| Vite | 7.3.1 |
| ESLint | 9.39.2 |

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)