### PR TITLE
feat: Private/Business task categorization (#198)

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,48 @@
           </svg>
         </button>
         <button
+          id="categoryPrivateToggle"
+          class="focus-mode-toggle category-filter-btn"
+          title="Privat"
+          aria-label="Filter private tasks"
+          style="display: none"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+            <polyline points="9 22 9 12 15 12 15 22" />
+          </svg>
+        </button>
+        <button
+          id="categoryBusinessToggle"
+          class="focus-mode-toggle category-filter-btn"
+          title="Beruflich"
+          aria-label="Filter business tasks"
+          style="display: none"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+          </svg>
+        </button>
+        <button
           id="settingsBtnHeader"
           class="settings-btn-header"
           title="Settings"
@@ -319,6 +361,36 @@
             <span id="quickAddDueDateLabel">Due Date</span>
           </label>
           <input type="date" id="quickAddDueDate" class="due-date-input" />
+        </div>
+
+        <!-- Category Selection (shown only when feature enabled) -->
+        <div id="quickAddCategoryConfig" class="category-config" style="display: none">
+          <label class="due-date-label">
+            <span id="quickAddCategoryLabel">Kategorie</span>
+          </label>
+          <div class="category-toggle-group">
+            <button
+              type="button"
+              class="btn btn-toggle category-select-btn active"
+              data-category=""
+            >
+              <span id="quickAddCategoryNone">Keine</span>
+            </button>
+            <button
+              type="button"
+              class="btn btn-toggle category-select-btn"
+              data-category="private"
+            >
+              <span id="quickAddCategoryPrivate">Privat</span>
+            </button>
+            <button
+              type="button"
+              class="btn btn-toggle category-select-btn"
+              data-category="business"
+            >
+              <span id="quickAddCategoryBusiness">Beruflich</span>
+            </button>
+          </div>
         </div>
 
         <div class="modal-buttons">
@@ -569,6 +641,22 @@
           </label>
           <p class="settings-info" id="smartFunctionsDesc">
             Automatisch Aufgaben als dringend markieren, wenn sie in 3 Tagen fällig sind
+          </p>
+        </div>
+
+        <div class="settings-separator"></div>
+
+        <!-- Category Filter Settings -->
+        <div class="settings-section">
+          <h4 class="settings-section-title" id="personalizeCategoryFilterTitle">
+            KATEGORIE-FILTER
+          </h4>
+          <label class="smart-functions-toggle">
+            <input type="checkbox" id="categoryFilterToggle" />
+            <span id="categoryFilterLabel">Kategorie-Filter aktivieren</span>
+          </label>
+          <p class="settings-info" id="categoryFilterDesc">
+            Aufgaben als Privat oder Beruflich kategorisieren
           </p>
         </div>
 

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -225,6 +225,14 @@ export async function saveTaskToFirestore(task, userId, db) {
     taskData.recurring = task.recurring;
   }
 
+  if (task.dueDate) {
+    taskData.dueDate = task.dueDate;
+  }
+
+  if (task.category) {
+    taskData.category = task.category;
+  }
+
   // Add to offline queue with retry logic and error handling
   try {
     await offlineQueue.add(
@@ -276,6 +284,14 @@ export async function updateTaskInFirestore(task, userId, db) {
 
   if (task.recurring) {
     updateData.recurring = task.recurring;
+  }
+
+  if (task.dueDate) {
+    updateData.dueDate = task.dueDate;
+  }
+
+  if (task.category) {
+    updateData.category = task.category;
   }
 
   // Add to offline queue with retry logic
@@ -384,6 +400,14 @@ export async function importGuestTasksToFirestore(userId, db) {
 
         if (task.recurring) {
           taskData.recurring = task.recurring;
+        }
+
+        if (task.dueDate) {
+          taskData.dueDate = task.dueDate;
+        }
+
+        if (task.category) {
+          taskData.category = task.category;
         }
 
         batch.set(docRef, taskData);

--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -118,7 +118,8 @@ function createTaskObject(
   segmentId,
   recurringConfig = null,
   createdAt = null,
-  dueDate = null
+  dueDate = null,
+  category = null
 ) {
   const task = {
     id: Date.now() + Math.random(), // Add random to avoid ID collisions
@@ -132,6 +133,11 @@ function createTaskObject(
   // Add due date if provided
   if (dueDate) {
     task.dueDate = dueDate;
+  }
+
+  // Add category if provided
+  if (category) {
+    task.category = category;
   }
 
   // Add recurring configuration if enabled
@@ -162,7 +168,8 @@ export function addTaskToSegment(
   segmentId,
   recurringConfig = null,
   saveCallback = null,
-  dueDate = null
+  dueDate = null,
+  category = null
 ) {
   // Input validation
   if (typeof taskText !== 'string') {
@@ -178,7 +185,7 @@ export function addTaskToSegment(
     throw new RangeError('Segment ID must be an integer between 1 and 5');
   }
 
-  const task = createTaskObject(taskText, segmentId, recurringConfig, null, dueDate);
+  const task = createTaskObject(taskText, segmentId, recurringConfig, null, dueDate, category);
   tasks[segmentId].push(task);
 
   // Call save callback if provided
@@ -281,6 +288,11 @@ export function moveTask(taskId, fromSegment, toSegment, saveCallback = null) {
     movedTask.dueDate = task.dueDate;
   }
 
+  // Preserve category if exists
+  if (task.category) {
+    movedTask.category = task.category;
+  }
+
   // Preserve recurring config if exists
   if (task.recurring) {
     movedTask.recurring = { ...task.recurring };
@@ -375,7 +387,8 @@ export function toggleTask(taskId, segmentId, saveCallback = null) {
           ...task.recurring,
         },
         nextOccurrence, // Set createdAt to future timestamp
-        task.dueDate // Preserve due date for recurring tasks
+        task.dueDate, // Preserve due date for recurring tasks
+        task.category // Preserve category for recurring tasks
       );
 
       // Add the new task to the same segment
@@ -528,6 +541,24 @@ export function filterTasks(searchTerm) {
     );
   }
 
+  return filtered;
+}
+
+/**
+ * Filter tasks by category
+ * @param {object} tasksToFilter - Tasks object grouped by segment
+ * @param {string|null} categoryFilter - 'private', 'business', or null (all)
+ * @returns {object} Filtered tasks
+ */
+export function filterByCategory(tasksToFilter, categoryFilter) {
+  if (!categoryFilter) return tasksToFilter;
+
+  const filtered = {};
+  for (let segmentId = 1; segmentId <= 5; segmentId++) {
+    filtered[segmentId] = (tasksToFilter[segmentId] || []).filter(
+      (task) => !task.category || task.category === categoryFilter
+    );
+  }
   return filtered;
 }
 

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -20,6 +20,14 @@ export const translations = {
       tooltip: 'Nur wichtige Aufgaben anzeigen (Q1 + Q2)',
       active: 'Fokus-Modus aktiv',
     },
+    categoryFilter: {
+      private: 'Privat',
+      business: 'Beruflich',
+      tooltipPrivate: 'Nur private Aufgaben anzeigen',
+      tooltipBusiness: 'Nur berufliche Aufgaben anzeigen',
+      activePrivate: 'Privat-Filter aktiv',
+      activeBusiness: 'Beruf-Filter aktiv',
+    },
     buttons: {
       add: 'Hinzufügen',
       cancel: 'Abbrechen',
@@ -58,6 +66,9 @@ export const translations = {
       smartFunctionsLabel: 'Smarte Funktionen aktivieren',
       smartFunctionsDesc:
         'Automatisch Aufgaben als dringend markieren, wenn sie in 3 Tagen fällig sind',
+      categoryFilter: 'KATEGORIE-FILTER',
+      categoryFilterLabel: 'Kategorie-Filter aktivieren',
+      categoryFilterDesc: 'Aufgaben als Privat oder Beruflich kategorisieren',
     },
     about: {
       title: 'Über',
@@ -100,6 +111,10 @@ export const translations = {
       inputPlaceholder: 'Was möchtest du tun?',
       monthDayLabel: 'Tag (1-31)',
       dueDate: 'Fällig am',
+      category: 'Kategorie',
+      categoryNone: 'Keine',
+      categoryPrivate: 'Privat',
+      categoryBusiness: 'Beruflich',
     },
     segmentModal: {
       title: 'Wähle ein Segment',
@@ -163,6 +178,14 @@ export const translations = {
       tooltip: 'Show only important tasks (Q1 + Q2)',
       active: 'Focus mode active',
     },
+    categoryFilter: {
+      private: 'Private',
+      business: 'Business',
+      tooltipPrivate: 'Show only private tasks',
+      tooltipBusiness: 'Show only business tasks',
+      activePrivate: 'Private filter active',
+      activeBusiness: 'Business filter active',
+    },
     buttons: {
       add: 'Add',
       cancel: 'Cancel',
@@ -200,6 +223,9 @@ export const translations = {
       smartFunctions: 'SMART FUNCTIONS',
       smartFunctionsLabel: 'Enable Smart Functions',
       smartFunctionsDesc: 'Automatically mark tasks as urgent when due within 3 days',
+      categoryFilter: 'CATEGORY FILTER',
+      categoryFilterLabel: 'Enable Category Filter',
+      categoryFilterDesc: 'Categorize tasks as Private or Business',
     },
     about: {
       title: 'About',
@@ -242,6 +268,10 @@ export const translations = {
       inputPlaceholder: 'What do you want to do?',
       monthDayLabel: 'Day (1-31)',
       dueDate: 'Due Date',
+      category: 'Category',
+      categoryNone: 'None',
+      categoryPrivate: 'Private',
+      categoryBusiness: 'Business',
     },
     segmentModal: {
       title: 'Choose a segment',
@@ -627,6 +657,60 @@ export function updateLanguageUI(renderAllTasksCallback) {
   const smartFunctionsDesc = document.getElementById('smartFunctionsDesc');
   if (smartFunctionsDesc) {
     smartFunctionsDesc.textContent = lang.personalize.smartFunctionsDesc;
+  }
+
+  // Update Category Filter section in Personalize Modal
+  const personalizeCategoryFilterTitle = document.getElementById('personalizeCategoryFilterTitle');
+  if (personalizeCategoryFilterTitle) {
+    personalizeCategoryFilterTitle.textContent = lang.personalize.categoryFilter;
+  }
+
+  const categoryFilterLabel = document.getElementById('categoryFilterLabel');
+  if (categoryFilterLabel) {
+    categoryFilterLabel.textContent = lang.personalize.categoryFilterLabel;
+  }
+
+  const categoryFilterDesc = document.getElementById('categoryFilterDesc');
+  if (categoryFilterDesc) {
+    categoryFilterDesc.textContent = lang.personalize.categoryFilterDesc;
+  }
+
+  // Update Category Filter header buttons
+  const categoryPrivateToggle = document.getElementById('categoryPrivateToggle');
+  if (categoryPrivateToggle) {
+    const isActive = categoryPrivateToggle.classList.contains('active');
+    categoryPrivateToggle.title = isActive
+      ? lang.categoryFilter.activePrivate
+      : lang.categoryFilter.tooltipPrivate;
+  }
+
+  const categoryBusinessToggle = document.getElementById('categoryBusinessToggle');
+  if (categoryBusinessToggle) {
+    const isActive = categoryBusinessToggle.classList.contains('active');
+    categoryBusinessToggle.title = isActive
+      ? lang.categoryFilter.activeBusiness
+      : lang.categoryFilter.tooltipBusiness;
+  }
+
+  // Update Quick Add Category labels
+  const quickAddCategoryLabel = document.getElementById('quickAddCategoryLabel');
+  if (quickAddCategoryLabel) {
+    quickAddCategoryLabel.textContent = lang.quickAddModal.category;
+  }
+
+  const quickAddCategoryNone = document.getElementById('quickAddCategoryNone');
+  if (quickAddCategoryNone) {
+    quickAddCategoryNone.textContent = lang.quickAddModal.categoryNone;
+  }
+
+  const quickAddCategoryPrivate = document.getElementById('quickAddCategoryPrivate');
+  if (quickAddCategoryPrivate) {
+    quickAddCategoryPrivate.textContent = lang.quickAddModal.categoryPrivate;
+  }
+
+  const quickAddCategoryBusiness = document.getElementById('quickAddCategoryBusiness');
+  if (quickAddCategoryBusiness) {
+    quickAddCategoryBusiness.textContent = lang.quickAddModal.categoryBusiness;
   }
 
   const personalizeThemeDark = document.getElementById('personalizeThemeDark');

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -708,6 +708,12 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     smartFunctionsToggle.checked = localStorage.getItem('smartFunctionsEnabled') === 'true';
   }
 
+  // Update category filter toggle state
+  const categoryFilterToggle = document.getElementById('categoryFilterToggle');
+  if (categoryFilterToggle) {
+    categoryFilterToggle.checked = localStorage.getItem('categoryFilterEnabled') === 'true';
+  }
+
   // Use event delegation for all personalize modal buttons
   const existingHandler = personalizeModal._clickHandler;
   if (existingHandler) {
@@ -765,6 +771,30 @@ export function openPersonalizeModal(currentLanguage = 'en') {
       localStorage.setItem('smartFunctionsEnabled', isEnabled.toString());
 
       // Trigger re-render if callback is provided
+      if (window.renderTasksCallback) {
+        window.renderTasksCallback();
+      }
+      return;
+    }
+
+    // Handle category filter toggle
+    if (target.id === 'categoryFilterToggle') {
+      const isEnabled = target.checked;
+      localStorage.setItem('categoryFilterEnabled', isEnabled.toString());
+
+      // Show/hide header buttons
+      const privateBtn = document.getElementById('categoryPrivateToggle');
+      const businessBtn = document.getElementById('categoryBusinessToggle');
+      if (privateBtn) privateBtn.style.display = isEnabled ? '' : 'none';
+      if (businessBtn) businessBtn.style.display = isEnabled ? '' : 'none';
+
+      // Clear filter when disabling
+      if (!isEnabled) {
+        localStorage.removeItem('categoryFilter');
+        if (privateBtn) privateBtn.classList.remove('active');
+        if (businessBtn) businessBtn.classList.remove('active');
+      }
+
       if (window.renderTasksCallback) {
         window.renderTasksCallback();
       }
@@ -1108,6 +1138,24 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
     dueDateInput.value = '';
   }
 
+  // Show/hide and reset category selector
+  const categoryConfig = document.getElementById('quickAddCategoryConfig');
+  const categoryEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
+  if (categoryConfig) {
+    categoryConfig.style.display = categoryEnabled ? '' : 'none';
+    const categoryBtns = categoryConfig.querySelectorAll('.category-select-btn');
+    categoryBtns.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.category === '');
+    });
+    // Setup category button click handlers
+    categoryBtns.forEach((btn) => {
+      btn.onclick = () => {
+        categoryBtns.forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+      };
+    });
+  }
+
   // Segment names
   const segmentNames = {
     1: { de: 'Do! (Wichtig & Dringend)', en: 'Do! (Important & Urgent)' },
@@ -1183,9 +1231,17 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
       }
     }
 
-    // Call callback with due date
+    // Get selected category if feature enabled
+    const categoryConfig = document.getElementById('quickAddCategoryConfig');
+    let category = null;
+    if (categoryConfig && categoryConfig.style.display !== 'none') {
+      const activeBtn = categoryConfig.querySelector('.category-select-btn.active');
+      category = activeBtn?.dataset.category || null;
+    }
+
+    // Call callback with due date and category
     if (onAddTask) {
-      onAddTask(text, segmentId, recurringConfig, dueDate);
+      onAddTask(text, segmentId, recurringConfig, dueDate, category);
     }
 
     // Close modal

--- a/script.js
+++ b/script.js
@@ -580,7 +580,11 @@ function setupEventListeners() {
       categoryPrivateToggle.classList.toggle('active', !isActive);
       categoryBusinessToggle.classList.remove('active');
 
-      localStorage.setItem('categoryFilter', isActive ? '' : 'private');
+      if (isActive) {
+        localStorage.removeItem('categoryFilter');
+      } else {
+        localStorage.setItem('categoryFilter', 'private');
+      }
 
       const lang = getTranslation();
       categoryPrivateToggle.title = !isActive
@@ -603,7 +607,11 @@ function setupEventListeners() {
       categoryBusinessToggle.classList.toggle('active', !isActive);
       categoryPrivateToggle.classList.remove('active');
 
-      localStorage.setItem('categoryFilter', isActive ? '' : 'business');
+      if (isActive) {
+        localStorage.removeItem('categoryFilter');
+      } else {
+        localStorage.setItem('categoryFilter', 'business');
+      }
 
       const lang = getTranslation();
       categoryBusinessToggle.title = !isActive

--- a/script.js
+++ b/script.js
@@ -51,6 +51,7 @@ import {
   setAllTasks,
   reorderTask,
   applySmartRules,
+  filterByCategory,
 } from './js/modules/tasks.js';
 import {
   initStorage,
@@ -162,10 +163,10 @@ async function loadAllTasks() {
 /**
  * Add task handler
  */
-function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null) {
+function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null, category = null) {
   if (!taskText || taskText.trim() === '') return;
 
-  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate);
+  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate, category);
 
   // Save to storage based on mode
   if (currentUser && db && !isGuestMode) {
@@ -443,9 +444,16 @@ function renderTasksWithCallbacks() {
 
   // Apply smart rules if enabled
   const smartFunctionsEnabled = localStorage.getItem('smartFunctionsEnabled') === 'true';
-  const tasksToRender = smartFunctionsEnabled
+  let tasksToRender = smartFunctionsEnabled
     ? applySmartRules(tasks, true, SMART_RULES.urgentThresholdDays)
     : tasks;
+
+  // Apply category filter if active
+  const categoryFilterEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
+  const categoryFilter = categoryFilterEnabled ? localStorage.getItem('categoryFilter') : null;
+  if (categoryFilter) {
+    tasksToRender = filterByCategory(tasksToRender, categoryFilter);
+  }
 
   renderAllTasks(tasksToRender, translations, getCurrentLanguage(), callbacks);
 
@@ -479,9 +487,11 @@ function setupEventListeners() {
         // Open Quick Add Modal with Q1 (Do!) pre-selected
         openQuickAddModal(
           1, // Segment 1 (Do!)
-          handleAddTask,
-          renderTasksWithCallbacks,
-          getCurrentLanguage
+          (text, selectedSegment, recurring, dueDate, category) => {
+            handleAddTask(text, selectedSegment || 1, recurring, dueDate, category);
+          },
+          translations,
+          getCurrentLanguage()
         );
 
         // Clear main input immediately after opening the modal
@@ -508,8 +518,8 @@ function setupEventListeners() {
       const segment = parseInt(e.target.dataset.segment);
       openQuickAddModal(
         segment,
-        (text, selectedSegment, recurring, dueDate) => {
-          handleAddTask(text, selectedSegment || segment, recurring, dueDate);
+        (text, selectedSegment, recurring, dueDate, category) => {
+          handleAddTask(text, selectedSegment || segment, recurring, dueDate, category);
         },
         translations,
         getCurrentLanguage()
@@ -542,6 +552,71 @@ function setupEventListeners() {
     // Set initial tooltip
     const lang = getTranslation();
     focusModeToggle.title = focusModeEnabled ? lang.focusMode.active : lang.focusMode.tooltip;
+  }
+
+  // Category Filter Buttons
+  const categoryPrivateToggle = document.getElementById('categoryPrivateToggle');
+  const categoryBusinessToggle = document.getElementById('categoryBusinessToggle');
+
+  // Show buttons if feature enabled
+  const categoryFilterEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
+  if (categoryFilterEnabled) {
+    if (categoryPrivateToggle) categoryPrivateToggle.style.display = '';
+    if (categoryBusinessToggle) categoryBusinessToggle.style.display = '';
+
+    // Load saved filter state
+    const savedCategoryFilter = localStorage.getItem('categoryFilter');
+    if (savedCategoryFilter === 'private' && categoryPrivateToggle) {
+      categoryPrivateToggle.classList.add('active');
+    } else if (savedCategoryFilter === 'business' && categoryBusinessToggle) {
+      categoryBusinessToggle.classList.add('active');
+    }
+  }
+
+  if (categoryPrivateToggle) {
+    categoryPrivateToggle.addEventListener('click', () => {
+      const isActive = categoryPrivateToggle.classList.contains('active');
+
+      categoryPrivateToggle.classList.toggle('active', !isActive);
+      categoryBusinessToggle.classList.remove('active');
+
+      localStorage.setItem('categoryFilter', isActive ? '' : 'private');
+
+      const lang = getTranslation();
+      categoryPrivateToggle.title = !isActive
+        ? lang.categoryFilter.activePrivate
+        : lang.categoryFilter.tooltipPrivate;
+
+      renderTasksWithCallbacks();
+    });
+
+    const lang = getTranslation();
+    categoryPrivateToggle.title = categoryPrivateToggle.classList.contains('active')
+      ? lang.categoryFilter.activePrivate
+      : lang.categoryFilter.tooltipPrivate;
+  }
+
+  if (categoryBusinessToggle) {
+    categoryBusinessToggle.addEventListener('click', () => {
+      const isActive = categoryBusinessToggle.classList.contains('active');
+
+      categoryBusinessToggle.classList.toggle('active', !isActive);
+      categoryPrivateToggle.classList.remove('active');
+
+      localStorage.setItem('categoryFilter', isActive ? '' : 'business');
+
+      const lang = getTranslation();
+      categoryBusinessToggle.title = !isActive
+        ? lang.categoryFilter.activeBusiness
+        : lang.categoryFilter.tooltipBusiness;
+
+      renderTasksWithCallbacks();
+    });
+
+    const lang = getTranslation();
+    categoryBusinessToggle.title = categoryBusinessToggle.classList.contains('active')
+      ? lang.categoryFilter.activeBusiness
+      : lang.categoryFilter.tooltipBusiness;
   }
 
   // Settings button (header)

--- a/style.css
+++ b/style.css
@@ -1644,6 +1644,31 @@ body.dark-mode .search-highlight {
   border-color: var(--primary);
 }
 
+/* Category Filter Styles */
+.category-config {
+  background: var(--task-bg);
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+}
+
+.category-toggle-group {
+  display: flex;
+  gap: 8px;
+}
+
+.category-select-btn {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 0.85em;
+}
+
+.category-select-btn.active {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
 /* Task Due Date Display */
 .task-due-date {
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Adds optional `category` property (`private` / `business`) to tasks for separating personal and work items
- Two filter buttons in the header (house icon = Private, briefcase icon = Business) toggle between views
- Uncategorized tasks appear in all views for backward compatibility
- Feature is opt-in via a toggle in the Personalize modal
- Category can be set when creating tasks via the Quick Add modal
- Also fixes a pre-existing bug where `dueDate` was never persisted to Firestore

## Changes
- **translations.js**: New strings for category filter, personalize toggle, and Quick Add selector (DE + EN)
- **tasks.js**: `category` parameter in task creation, `filterByCategory()` export
- **storage.js**: `dueDate` + `category` persistence in Firestore (save, update, import)
- **index.html**: Header filter buttons, Personalize checkbox, Quick Add category selector
- **style.css**: Category button and toggle styles
- **ui.js**: Personalize toggle handler, Quick Add category selector logic
- **script.js**: Filter state, render integration, event handlers

## Test plan
- [x] `npx vitest run` — 150 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — successful
- [ ] Manual: Feature disabled → no buttons visible, no category selector in Quick Add
- [ ] Manual: Feature enabled → buttons appear, filter works correctly
- [ ] Manual: Old tasks without category appear in all views
- [ ] Manual: New tasks with category are filtered correctly

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)