### PR TITLE
fix: Stop repeated auto-backup failure notifications

### DIFF
--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -216,6 +216,10 @@ async function cleanupOldBackups(storage, userId) {
  * @returns {boolean} True if backup should run
  */
 export function shouldAutoBackup() {
+  // Stop retrying after 3 consecutive failures until user does manual backup
+  const failureCount = parseInt(localStorage.getItem('autoBackupFailureCount') || '0');
+  if (failureCount >= 3) return false;
+
   const lastBackup = localStorage.getItem('lastAutoBackup');
   if (!lastBackup) return true;
 
@@ -248,6 +252,9 @@ export function trackBackupFailure() {
   const failureCount = parseInt(localStorage.getItem('autoBackupFailureCount') || '0');
   const newCount = failureCount + 1;
   localStorage.setItem('autoBackupFailureCount', newCount.toString());
+
+  // Set last attempt timestamp so shouldAutoBackup() respects weekly interval even on failure
+  localStorage.setItem('lastAutoBackup', Date.now().toString());
 
   // Notify user only after 3 consecutive failures
   return newCount >= 3;


### PR DESCRIPTION
## Summary
- Auto-backup failures were causing a persistent error notification on every login after 3 failures
- Root cause: `lastAutoBackup` timestamp was never set on failure, causing immediate retry on every login. Failure counter grew indefinitely and was never reset
- Now sets `lastAutoBackup` on failure too (respects weekly interval between retries)
- Stops auto-backup attempts entirely after 3 consecutive failures (until manual backup resets the counter)

## Test plan
- [ ] Login with an account — no backup error should appear
- [ ] Verify `npx vitest run tests/unit/backup.test.js` passes (8 tests)
- [ ] Verify manual backup in Settings still works and resets the auto-backup timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)