### PR TITLE
fix(eslint): 0 warnings — unused catch variables & dead import

### DIFF
--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -53,7 +53,7 @@ function isSessionStorageAvailable() {
     sessionStorage.setItem(testKey, 'test');
     sessionStorage.removeItem(testKey);
     return true;
-  } catch (e) {
+  } catch (_e) {
     return false;
   }
 }
@@ -229,7 +229,7 @@ export async function initAuth() {
 
           showLogin();
         }
-      } catch (error) {
+      } catch (_error) {
         isGuestMode = false;
         showLogin();
       }

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -150,7 +150,7 @@ export async function loadGuestTasks() {
 
     // Return empty tasks structure if no data
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
-  } catch (error) {
+  } catch (_error) {
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
   }
 }
@@ -187,7 +187,7 @@ export async function loadUserTasks(userId, db) {
     });
 
     return tasks;
-  } catch (error) {
+  } catch (_error) {
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
   }
 }
@@ -534,7 +534,7 @@ export async function requestPersistentStorage() {
     try {
       const isPersisted = await navigator.storage.persist();
       return isPersisted;
-    } catch (error) {
+    } catch (_error) {
       return false;
     }
   }
@@ -550,7 +550,7 @@ export async function checkPersistentStorage() {
     try {
       const isPersisted = await navigator.storage.persisted();
       return isPersisted;
-    } catch (error) {
+    } catch (_error) {
       return false;
     }
   }

--- a/js/modules/store.js
+++ b/js/modules/store.js
@@ -242,7 +242,7 @@ class Store {
         // For objects/arrays, use JSON stringify for deep comparison
         try {
           return JSON.stringify(newValue) !== JSON.stringify(prevValue);
-        } catch (e) {
+        } catch (_e) {
           // Fallback to reference comparison if JSON.stringify fails
           return newValue !== prevValue;
         }

--- a/js/modules/version.js
+++ b/js/modules/version.js
@@ -22,7 +22,7 @@ export async function loadVersion() {
     const data = await response.json();
     APP_VERSION = 'v' + data.version;
     return APP_VERSION;
-  } catch (error) {
+  } catch (_error) {
     // Silently use fallback version if loading fails
     console.debug('Using fallback version:', APP_VERSION); // debug:
     return APP_VERSION;

--- a/script.js
+++ b/script.js
@@ -69,7 +69,6 @@ import {
 } from './js/modules/storage.js';
 import {
   renderAllTasks,
-  openModal,
   closeModal,
   openQuickAddModal,
   openSettingsModal,
@@ -1225,7 +1224,7 @@ async function initApp() {
       updateOnlineStatus();
     }
     // If neither guest nor logged in, auth.js will show login screen
-  } catch (error) {
+  } catch (_error) {
     // Error loading cached auth state
   }
 

--- a/update-cache-version.js
+++ b/update-cache-version.js
@@ -101,6 +101,6 @@ try {
   updateIndexHtml();
   updateManifest();
   createVersionInfo();
-} catch (error) {
+} catch (_error) {
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Rename unused `catch(error/e)` variables to `_error/_e` in `auth.js`, `storage.js`, `store.js`, `version.js`, `script.js`, `update-cache-version.js`
- Remove unused `openModal` import in `script.js`

**Result:** ESLint 0 errors, 0 warnings (previously 11 warnings)

## Test plan
- [x] ESLint: 0 errors, 0 warnings
- [x] 150 Tests passing
- [x] Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)