### PR TITLE
fix(ios): safe area inset for header on iPad/iPhone (#224)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <title>Eisenhauer Matrix</title>
 

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -53,7 +53,7 @@ function isSessionStorageAvailable() {
     sessionStorage.setItem(testKey, 'test');
     sessionStorage.removeItem(testKey);
     return true;
-  } catch (e) {
+  } catch (_e) {
     return false;
   }
 }
@@ -229,7 +229,7 @@ export async function initAuth() {
 
           showLogin();
         }
-      } catch (error) {
+      } catch (_error) {
         isGuestMode = false;
         showLogin();
       }

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -150,7 +150,7 @@ export async function loadGuestTasks() {
 
     // Return empty tasks structure if no data
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
-  } catch (error) {
+  } catch (_error) {
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
   }
 }
@@ -187,7 +187,7 @@ export async function loadUserTasks(userId, db) {
     });
 
     return tasks;
-  } catch (error) {
+  } catch (_error) {
     return { 1: [], 2: [], 3: [], 4: [], 5: [] };
   }
 }
@@ -534,7 +534,7 @@ export async function requestPersistentStorage() {
     try {
       const isPersisted = await navigator.storage.persist();
       return isPersisted;
-    } catch (error) {
+    } catch (_error) {
       return false;
     }
   }
@@ -550,7 +550,7 @@ export async function checkPersistentStorage() {
     try {
       const isPersisted = await navigator.storage.persisted();
       return isPersisted;
-    } catch (error) {
+    } catch (_error) {
       return false;
     }
   }

--- a/js/modules/store.js
+++ b/js/modules/store.js
@@ -242,7 +242,7 @@ class Store {
         // For objects/arrays, use JSON stringify for deep comparison
         try {
           return JSON.stringify(newValue) !== JSON.stringify(prevValue);
-        } catch (e) {
+        } catch (_e) {
           // Fallback to reference comparison if JSON.stringify fails
           return newValue !== prevValue;
         }

--- a/js/modules/version.js
+++ b/js/modules/version.js
@@ -22,7 +22,7 @@ export async function loadVersion() {
     const data = await response.json();
     APP_VERSION = 'v' + data.version;
     return APP_VERSION;
-  } catch (error) {
+  } catch (_error) {
     // Silently use fallback version if loading fails
     console.debug('Using fallback version:', APP_VERSION); // debug:
     return APP_VERSION;

--- a/script.js
+++ b/script.js
@@ -69,7 +69,6 @@ import {
 } from './js/modules/storage.js';
 import {
   renderAllTasks,
-  openModal,
   closeModal,
   openQuickAddModal,
   openSettingsModal,
@@ -1225,7 +1224,7 @@ async function initApp() {
       updateOnlineStatus();
     }
     // If neither guest nor logged in, auth.js will show login screen
-  } catch (error) {
+  } catch (_error) {
     // Error loading cached auth state
   }
 

--- a/style.css
+++ b/style.css
@@ -228,6 +228,7 @@ header,
   justify-content: space-between;
   align-items: center;
   padding: 15px 20px;
+  padding-top: calc(15px + env(safe-area-inset-top));
   flex-shrink: 0;
   border-bottom: 1px solid var(--border-color);
 }

--- a/update-cache-version.js
+++ b/update-cache-version.js
@@ -101,6 +101,6 @@ try {
   updateIndexHtml();
   updateManifest();
   createVersionInfo();
-} catch (error) {
+} catch (_error) {
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Adds `viewport-fit=cover` to the meta viewport tag so iOS respects the full display area
- Adds `padding-top: calc(15px + env(safe-area-inset-top))` to the app header so it's not hidden behind the browser toolbar on iPadOS/iOS

## Root Cause
On iOS/iPadOS, Safari's browser toolbar overlaps app content when `viewport-fit` is not set to `cover`. Without `env(safe-area-inset-top)`, the header has no way to know how much space to leave for the browser UI.

## Test plan
- [ ] Open app on iOS/iPadOS in Safari — header should be fully visible below the browser toolbar
- [ ] Verify no visual regression on Android and desktop

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)