### PR TITLE
fix(ios): safe-area-inset-bottom for undo toast

### DIFF
--- a/style.css
+++ b/style.css
@@ -2382,7 +2382,7 @@ body.dark-mode .settings-warning {
 }
 
 .undo-toast.show {
-  bottom: 24px;
+  bottom: calc(24px + env(safe-area-inset-bottom));
 }
 
 .undo-toast-message {


### PR DESCRIPTION
## Summary
- Adds `env(safe-area-inset-bottom)` to the undo toast's `bottom` value so it's not obscured by the iPhone/iPad home indicator

Addresses Copilot review suggestion from PR #230.

## Test plan
- [ ] Undo toast auf iPhone/iPad testen — sollte über dem Home Indicator erscheinen
- [ ] Kein visueller Unterschied auf Android/Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)