### PR TITLE
fix: repair Focus Mode icon disappearing on older Android devices (#235)

### DIFF
--- a/style.css
+++ b/style.css
@@ -2687,6 +2687,12 @@ body.dark-mode .undo-toast {
   color: var(--text-color);
 }
 
+/* Explicitly set SVG stroke via CSS to fix currentColor inheritance bug on older Android WebView */
+.focus-mode-toggle svg {
+  stroke: currentColor;
+  transition: stroke 0.2s ease;
+}
+
 .focus-mode-toggle:hover {
   background: var(--hover-bg);
   border-color: var(--primary-color);
@@ -2697,6 +2703,10 @@ body.dark-mode .undo-toast {
   border-color: var(--primary-color);
   color: white;
   box-shadow: 0 0 12px rgba(var(--primary-rgb), 0.4);
+}
+
+.focus-mode-toggle.active svg {
+  stroke: white;
 }
 
 /* Focus Mode Active - Hide Q3 and Q4 */


### PR DESCRIPTION
## Problem

Auf älteren Android-Geräten (ältere WebView-Versionen) verschwindet das Focus-Mode-Icon nach dem Drücken des Buttons. Erst beim erneuten Drücken erscheint es wieder.

**Ursache:** Ältere Android WebView-Versionen aktualisieren SVG-Elemente mit `stroke="currentColor"` nicht zuverlässig, wenn die CSS `color`-Property des Elternelements via JavaScript-Klassentoggle geändert wird.

## Lösung

SVG-Stroke-Farben explizit via CSS setzen statt auf `currentColor`-Vererbung zu vertrauen:
- `.focus-mode-toggle svg { stroke: currentColor }`
- `.focus-mode-toggle.active svg { stroke: white }`

Fix gilt auch für die Category-Filter-Buttons mit derselben Klasse.

Closes #235