### PR TITLE
fix(css): force GPU compositing on focus-mode-toggle (#235)

### DIFF
--- a/style.css
+++ b/style.css
@@ -2685,6 +2685,9 @@ body.dark-mode .undo-toast {
   align-items: center;
   justify-content: center;
   color: var(--text-color);
+  /* Force GPU compositing to prevent SVG icon disappearing on old Android WebViews */
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 
 .focus-mode-toggle:hover {


### PR DESCRIPTION
## Problem

Auf alten Android-Geräten verschwindet das Auge-Icon des Focus Mode Buttons nach dem ersten Klick. Bei erneutem Klick auf die Stelle erscheint es wieder.

## Ursache

Alter Android WebView (Chromium): Wenn `background`, `border-color` und `box-shadow` per CSS geändert werden, triggert das keinen Repaint der Kind-Elemente (SVG) — klassischer Compositing-Bug.

## Fix

`transform: translateZ(0)` / `-webkit-transform: translateZ(0)` auf `.focus-mode-toggle` erzwingt GPU-Compositing für dieses Element. Dadurch wird das Icon auf einem eigenen Layer gerendert und bleibt bei State-Änderungen sichtbar.

Fixes #235

## Test plan
- [ ] Focus Mode Button klicken → Icon bleibt sichtbar
- [ ] Button aktiv (blau) → Icon sichtbar
- [ ] Button inaktiv → Icon sichtbar
- [ ] Auf altem Android-Gerät / TWA testen (Chrome 80–90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)