### PR TITLE
fix(android): replace old purple splash screen with black background

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -48,23 +48,19 @@
 
             <meta-data
                 android:name="android.support.customtabs.trusted.STATUS_BAR_COLOR"
-                android:resource="@color/colorPrimary" />
+                android:resource="@color/statusBarColor" />
 
             <meta-data
                 android:name="android.support.customtabs.trusted.NAVIGATION_BAR_COLOR"
-                android:resource="@color/colorPrimary" />
-
-            <meta-data
-                android:name="android.support.customtabs.trusted.SPLASH_IMAGE_DRAWABLE"
-                android:resource="@drawable/splash_background" />
+                android:resource="@color/navigationBarColor" />
 
             <meta-data
                 android:name="android.support.customtabs.trusted.SPLASH_SCREEN_BACKGROUND_COLOR"
-                android:resource="@color/colorPrimary" />
+                android:resource="@color/splashBackground" />
 
             <meta-data
                 android:name="android.support.customtabs.trusted.SPLASH_SCREEN_FADE_OUT_DURATION"
-                android:value="500" />
+                android:value="300" />
 
             <meta-data
                 android:name="android.support.customtabs.trusted.FILE_PROVIDER_AUTHORITY"

--- a/Android/app/src/main/res/drawable/splash_background.xml
+++ b/Android/app/src/main/res/drawable/splash_background.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Solid black background to seamlessly blend into the PWA splash screen -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/splashBackground" />
-</shape>

--- a/Android/app/src/main/res/drawable/splash_background.xml
+++ b/Android/app/src/main/res/drawable/splash_background.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Background gradient -->
-    <item>
-        <shape android:shape="rectangle">
-            <gradient
-                android:angle="135"
-                android:startColor="@color/colorPrimary"
-                android:centerColor="@color/splashGradientCenter"
-                android:endColor="@color/colorPrimary"
-                android:type="linear" />
-        </shape>
-    </item>
-    
-    <!-- App logo centered and larger -->
-    <item
-        android:width="192dp"
-        android:height="192dp"
-        android:gravity="center">
-        <bitmap
-            android:src="@mipmap/ic_launcher"
-            android:gravity="center" />
-    </item>
-</layer-list>
+<!-- Solid black background to seamlessly blend into the PWA splash screen -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/splashBackground" />
+</shape>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Theme colors from PWA manifest.json -->
-    <color name="colorPrimary">#667eea</color>
-    <color name="colorPrimaryDark">#5568d3</color>
-    <color name="colorAccent">#667eea</color>
+    <!-- Theme colors matching PWA manifest.json (#000000) -->
+    <color name="colorPrimary">#000000</color>
+    <color name="colorPrimaryDark">#000000</color>
+    <color name="colorAccent">#000000</color>
 
     <!-- Background colors -->
-    <color name="backgroundColor">#667eea</color>
-    <color name="splashBackground">#667eea</color>
-    <color name="splashGradientCenter">#764ba2</color>
+    <color name="backgroundColor">#000000</color>
+    <color name="splashBackground">#000000</color>
 
     <!-- Status bar and navigation bar -->
-    <color name="statusBarColor">#667eea</color>
-    <color name="navigationBarColor">#667eea</color>
+    <color name="statusBarColor">#000000</color>
+    <color name="navigationBarColor">#000000</color>
 </resources>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Theme colors matching PWA manifest.json (#000000) -->
-    <color name="colorPrimary">#000000</color>
-    <color name="colorPrimaryDark">#000000</color>
-    <color name="colorAccent">#000000</color>
-
-    <!-- Background colors -->
-    <color name="backgroundColor">#000000</color>
+    <!-- All colors #000000 to match PWA manifest.json theme -->
     <color name="splashBackground">#000000</color>
-
-    <!-- Status bar and navigation bar -->
     <color name="statusBarColor">#000000</color>
     <color name="navigationBarColor">#000000</color>
 </resources>


### PR DESCRIPTION
## Summary
- Native TWA splash screen used outdated indigo/purple gradient (#667eea → #764ba2) that flashed before the modern black PWA splash screen
- All Android colors changed to #000000 to match PWA theme
- Splash drawable simplified from gradient + icon to solid black shape
- Removed `SPLASH_IMAGE_DRAWABLE` meta-data, reduced fade-out from 500ms → 300ms

## Test plan
- [ ] Build APK via `build-android.yml` or local Gradle build
- [ ] Install on Android device — verify no purple flash on app start
- [ ] Verify seamless transition from black native splash → animated PWA splash
- [ ] Test on older Android devices (API 26+)

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)