### PR TITLE
debug: Sichtbarer On-Device-Fehlerreport für Splash-Hang

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,48 @@
         </svg>
         <span class="splash-title">Eisenhauer</span>
       </div>
+      <!-- DIAGNOSTICS: visible on-device error report (debug/splash-hang-diagnostics) -->
+      <div
+        id="splashDiag"
+        style="
+          display: none;
+          position: absolute;
+          left: 12px;
+          right: 12px;
+          bottom: 12px;
+          max-height: 60vh;
+          overflow: auto;
+          background: rgba(0, 0, 0, 0.85);
+          color: #ffb4b4;
+          font: 12px/1.4 monospace;
+          padding: 12px;
+          border-radius: 8px;
+          text-align: left;
+          white-space: pre-wrap;
+          word-break: break-word;
+          z-index: 100000;
+        "
+      >
+        <div style="color: #fff; font-weight: bold; margin-bottom: 6px">
+          ⚠️ Startfehler (Diagnose-Build)
+        </div>
+        <div id="splashDiagBody"></div>
+        <button
+          id="splashDiagCopy"
+          type="button"
+          style="
+            margin-top: 10px;
+            padding: 8px 14px;
+            font: 13px sans-serif;
+            background: #fff;
+            color: #000;
+            border: 0;
+            border-radius: 6px;
+          "
+        >
+          Fehlertext kopieren
+        </button>
+      </div>
     </div>
 
     <!-- Staging Banner -->
@@ -904,6 +946,11 @@
 
     <!-- Main App (ES6 Module with Firebase Modular SDK) -->
     <!-- Firebase, localforage, and chart.js are loaded as npm packages and imported in script.js -->
+    <!-- DIAGNOSTICS (debug/splash-hang-diagnostics): visible on-device error report.
+         Loaded BEFORE the module so it can catch module import/eval failures.
+         TEMPORARY — remove before production release. -->
+    <script src="js/diag.js?v=diag1"></script>
+
     <script type="module" src="script.js?v=1.12.0"></script>
 
     <!-- Register Service Worker with Cache Busting -->

--- a/public/js/diag.js
+++ b/public/js/diag.js
@@ -23,17 +23,18 @@
     return document.getElementById(id);
   }
 
-  function showDiag(title, detail) {
-    reported.push(title + '\n' + detail);
+  function showDiag(title, detail, attempt) {
     const box = el('splashDiag');
     const body = el('splashDiagBody');
     if (!box || !body) {
-      // Splash/diag DOM not ready yet — retry shortly.
-      setTimeout(function () {
-        showDiag(title, detail);
-      }, 200);
+      if ((attempt || 0) < 10) {
+        setTimeout(function () {
+          showDiag(title, detail, (attempt || 0) + 1);
+        }, 200);
+      }
       return;
     }
+    reported.push(title + '\n' + detail);
     // Keep the splash visible (so the report is readable) but reveal the report.
     const splash = el('splashScreen');
     if (splash) {

--- a/public/js/diag.js
+++ b/public/js/diag.js
@@ -1,0 +1,136 @@
+/**
+ * DIAGNOSTICS — splash-hang investigation (branch: debug/splash-hang-diagnostics)
+ *
+ * Purpose: make a fatal startup error VISIBLE on the device instead of leaving
+ * the splash screen hanging forever. This is a temporary debug aid; it must be
+ * removed (or guarded behind a flag) before any production release.
+ *
+ * Loaded as a classic script BEFORE script.js so it can also catch:
+ *   - uncaught errors thrown from the ES module (script.js)
+ *   - unhandled promise rejections during async initApp()
+ *   - module import / evaluation failures
+ *
+ * It does NOT change app logic. It only observes errors and, as a safety net,
+ * force-hides the splash after a hard timeout so the user is never stuck.
+ */
+(function () {
+  'use strict';
+
+  const HARD_SPLASH_TIMEOUT_MS = 8000;
+  const reported = [];
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function showDiag(title, detail) {
+    reported.push(title + '\n' + detail);
+    const box = el('splashDiag');
+    const body = el('splashDiagBody');
+    if (!box || !body) {
+      // Splash/diag DOM not ready yet — retry shortly.
+      setTimeout(function () {
+        showDiag(title, detail);
+      }, 200);
+      return;
+    }
+    // Keep the splash visible (so the report is readable) but reveal the report.
+    const splash = el('splashScreen');
+    if (splash) {
+      splash.classList.remove('hidden');
+      splash.style.display = '';
+    }
+    box.style.display = 'block';
+    body.textContent = reported.join('\n\n──────────\n\n');
+  }
+
+  function format(err) {
+    if (!err) return '(no error object)';
+    if (err instanceof Error) {
+      return (
+        (err.name || 'Error') + ': ' + (err.message || '') + '\n' + (err.stack || '(no stack)')
+      );
+    }
+    try {
+      return typeof err === 'string' ? err : JSON.stringify(err);
+    } catch (_e) {
+      return String(err);
+    }
+  }
+
+  function ctx() {
+    const nav = navigator || {};
+    return (
+      'UA: ' +
+      (nav.userAgent || '?') +
+      '\n' +
+      'online: ' +
+      (typeof nav.onLine === 'boolean' ? nav.onLine : '?') +
+      '\n' +
+      'lang: ' +
+      (nav.language || '?') +
+      '\n' +
+      'readyState: ' +
+      (document.readyState || '?') +
+      '\n' +
+      'time: ' +
+      new Date().toISOString()
+    );
+  }
+
+  // --- Global error hooks -------------------------------------------------
+  window.addEventListener('error', function (e) {
+    // Resource load errors (e.g. failed module import) have no e.error
+    let detail = e && e.error ? format(e.error) : (e && e.message) || 'unknown error';
+    if (e && e.filename) {
+      detail += '\nat ' + e.filename + ':' + e.lineno + ':' + e.colno;
+    }
+    showDiag('window.error', detail + '\n\n' + ctx());
+  });
+
+  window.addEventListener('unhandledrejection', function (e) {
+    showDiag('unhandledrejection', format(e && e.reason) + '\n\n' + ctx());
+  });
+
+  // Expose a manual reporter so script.js can route caught init errors here.
+  window.__diagReport = function (label, err) {
+    showDiag(label || 'init error', format(err) + '\n\n' + ctx());
+  };
+
+  // --- Copy button --------------------------------------------------------
+  document.addEventListener('click', function (e) {
+    if (e.target && e.target.id === 'splashDiagCopy') {
+      const text = reported.join('\n\n──────────\n\n') + '\n\n' + ctx();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          function () {
+            e.target.textContent = '✓ kopiert';
+          },
+          function () {
+            e.target.textContent = 'Kopieren fehlgeschlagen';
+          }
+        );
+      } else {
+        e.target.textContent = 'Clipboard n/a';
+      }
+    }
+  });
+
+  // --- Hard safety net: never let the splash hang forever -----------------
+  setTimeout(function () {
+    const splash = el('splashScreen');
+    // If a diagnostic was shown, KEEP the splash so the report stays readable.
+    if (reported.length > 0) return;
+    if (splash && !splash.classList.contains('hidden')) {
+      // No error captured but still on splash after timeout: surface that fact.
+      showDiag(
+        'splash-timeout',
+        'Splash war nach ' +
+          HARD_SPLASH_TIMEOUT_MS +
+          'ms noch sichtbar und kein Fehler wurde abgefangen.\n' +
+          'initApp() ist vermutlich an einem await hängengeblieben (Firestore/Firebase/Storage).\n\n' +
+          ctx()
+      );
+    }
+  }, HARD_SPLASH_TIMEOUT_MS);
+})();

--- a/script.js
+++ b/script.js
@@ -467,25 +467,37 @@ function renderTasksWithCallbacks() {
     onReorder: handleReorderTask,
   };
 
-  // Apply smart rules if enabled
-  const smartFunctionsEnabled = localStorage.getItem('smartFunctionsEnabled') === 'true';
-  let tasksToRender = smartFunctionsEnabled
-    ? applySmartRules(tasks, true, SMART_RULES.urgentThresholdDays)
-    : tasks;
+  // DIAGNOSTICS (debug/splash-hang-diagnostics): the pre-render transforms below
+  // (applySmartRules / filterByCategory) and the post-render hooks
+  // (setupDropZones / rescheduleRemindersIfActive) previously ran UNGUARDED.
+  // A throw here aborts initApp before the splash is hidden → splash hangs.
+  // Wrap defensively AND report the real error so we can see it on the device.
+  try {
+    // Apply smart rules if enabled
+    const smartFunctionsEnabled = localStorage.getItem('smartFunctionsEnabled') === 'true';
+    let tasksToRender = smartFunctionsEnabled
+      ? applySmartRules(tasks, true, SMART_RULES.urgentThresholdDays)
+      : tasks;
 
-  // Apply category filter based on the active calendar switcher
-  const categoryFilter = localStorage.getItem('categoryFilter');
-  if (categoryFilter) {
-    tasksToRender = filterByCategory(tasksToRender, categoryFilter);
+    // Apply category filter based on the active calendar switcher
+    const categoryFilter = localStorage.getItem('categoryFilter');
+    if (categoryFilter) {
+      tasksToRender = filterByCategory(tasksToRender, categoryFilter);
+    }
+
+    renderAllTasks(tasksToRender, translations, getCurrentLanguage(), callbacks);
+
+    // Setup drop zones for desktop drag & drop
+    setupDropZones(handleMoveTask);
+
+    // Keep reminder schedule in sync with current task list
+    rescheduleRemindersIfActive();
+  } catch (error) {
+    if (typeof window.__diagReport === 'function') {
+      window.__diagReport('renderTasksWithCallbacks failed', error);
+    }
+    console.error('renderTasksWithCallbacks failed:', error);
   }
-
-  renderAllTasks(tasksToRender, translations, getCurrentLanguage(), callbacks);
-
-  // Setup drop zones for desktop drag & drop
-  setupDropZones(handleMoveTask);
-
-  // Keep reminder schedule in sync with current task list
-  rescheduleRemindersIfActive();
 }
 
 function rescheduleRemindersIfActive() {
@@ -1195,8 +1207,13 @@ async function initApp() {
       updateOnlineStatus();
     }
     // If neither guest nor logged in, auth.js will show login screen
-  } catch (_error) {
-    // Error loading cached auth state
+  } catch (error) {
+    // DIAGNOSTICS (debug/splash-hang-diagnostics): surface the real cause on-device
+    // instead of silently swallowing it (which leaves the splash hanging).
+    if (typeof window.__diagReport === 'function') {
+      window.__diagReport('initApp: early-load failed', error);
+    }
+    console.error('initApp early-load failed:', error);
   }
 
   // Note: Event listeners and tasks are loaded ABOVE for instant start


### PR DESCRIPTION
## Ziel
Reproduzierbarer **Splash-Hang** auf Mobilgeräten (Android/iOS): Der Splash-Screen baut sich vollständig auf und bleibt dann stehen. Auf dem PC läuft die App normal. Diese PR fügt **temporäre Diagnose-Instrumentierung** hinzu, um den echten Fehler **direkt auf dem Gerät sichtbar** zu machen (statt zu raten) — Eisenhauer ist eine TWA/PWA, daher reicht ein Web-Deploy, keine neue APK nötig.

## Hypothese (was die Diagnose belegen soll)
Die letzten PRs brachten **Render-Resilienz** (`renderAllTasks`/`renderSegment` überspringen korrupte Tasks), aber **keine persistente Daten-Reparatur**. Korrupte Daten leben weiter in Firestore → PC-Nutzung repariert nichts fürs Telefon. Der Hang entsteht vermutlich, weil `renderTasksWithCallbacks()` die **ungeschützten** Transforms `applySmartRules`/`filterByCategory` (+ `setupDropZones`/`rescheduleRemindersIfActive`) **vor** dem Splash-Hide aufruft — ein Throw dort bricht `initApp` ab, der Splash-Hide wird nie registriert.

## Änderungen
- **`public/js/diag.js`** (neu): klassisches Script, VOR dem ES-Modul geladen. Fängt `window.error`, `unhandledrejection` und per `window.__diagReport()` geroutete Init-Fehler ab und zeigt **Message + Stacktrace + Geräte-Kontext** sichtbar im Splash (mit Kopier-Button). Hard-Timeout (8s) meldet, falls der Splash ohne abgefangenen Fehler hängt (→ Hinweis auf hängendes `await`).
- **`index.html`**: Diag-Overlay im Splash + Script-Tag.
- **`script.js`**: gefangene Fehler in `initApp` (early-load) und `renderTasksWithCallbacks` an `__diagReport` routen statt still zu schlucken; `renderTasksWithCallbacks` defensiv gewrappt.

## Test auf dem Gerät
Nach Merge deployt CI automatisch nach `https://s540d.github.io/Eisenhauer/testing/`. Dort am betroffenen Telefon öffnen → der Fehler erscheint im Splash → "Fehlertext kopieren" → hierher posten.

## ⚠️ Temporär
Reine Diagnose. **Vor jedem Produktiv-Release wieder entfernen** (Branch-Name + Code-Kommentare markieren das).

🤖 Generated with [Claude Code](https://claude.com/claude-code)