### PR TITLE
fix: Firebase env vars im Deploy-Workflow an Vite übergeben

### DIFF
--- a/.github/workflows/deploy-unified.yml
+++ b/.github/workflows/deploy-unified.yml
@@ -93,6 +93,14 @@ jobs:
 
       - name: Build ${{ steps.env.outputs.environment }}
         run: npm run ${{ steps.env.outputs.build_script }}
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Problem
Der CI-Build für `testing` (und auch `production`) hat die `VITE_FIREBASE_*`-Variablen nicht bekommen. Firebase warf beim Modul-Load sofort `auth/invalid-api-key` → das gesamte `script.js`-Modul schlägt fehl → `initApp()` wird nie erreicht → **Splash bleibt hängen** (bestätigt durch Diagnose-Build PR #303).

Betroffen: alle Deployments über den `deploy-unified.yml`-Workflow.

**Warum funktioniert Produktion trotzdem?** Das erklärt sich durch den Service Worker: einmal erfolgreich deployed (lokal mit `.env.production`) wird der Build gecached. Neue CI-Builds ohne Secrets landen nur, wenn der SW-Cache ungültig wird — auf einem frischen Gerät (oder nach Cache-Clear) schlägt auch production fehl.

## Fix
`env:`-Block im Build-Schritt: die vorhandenen `FIREBASE_*`-Repo-Secrets werden als `VITE_FIREBASE_*` an Vite übergeben. `testing`/`staging` nutzen dasselbe Firebase-Projekt wie `production`.

## Test
Nach Merge deployt CI nach `https://s540d.github.io/Eisenhauer/testing/` — diesmal mit gültigem API-Key. Der Diagnose-Build (PR #303, bereits in testing) zeigt dann keinen Fehler mehr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)