### PR TITLE
Release: testing → main (v1.12.1)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
   statuses: write
 
 jobs:

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 35
-        versionCode 24
-        versionName "1.12.0"  // Match PWA version
+        versionCode 25
+        versionName "1.12.1"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
-    <link rel="stylesheet" href="style.css?v=1.12.0" />
+    <link rel="stylesheet" href="style.css?v=1.12.1" />
   </head>
   <body>
     <!-- Splash Screen -->
@@ -904,7 +904,7 @@
 
     <!-- Main App (ES6 Module with Firebase Modular SDK) -->
     <!-- Firebase, localforage, and chart.js are loaded as npm packages and imported in script.js -->
-    <script type="module" src="script.js?v=1.12.0"></script>
+    <script type="module" src="script.js?v=1.12.1"></script>
 
     <!-- Register Service Worker with Cache Busting -->
     <script src="js/sw-register.js?v=1776883834344"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Eisenhauer Matrix",
   "short_name": "Eisenhauer",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Task Management nach der Eisenhauer-Matrix-Methode",
   "start_url": "./index.html",
   "display": "standalone",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eisenhauer-matrix",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Eine moderne, mobile-first Progressive Web App zur Aufgabenverwaltung nach der Eisenhauer-Matrix-Methode.",
   "main": "index.html",
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.12.0",
-  "buildDate": "2026-06-03",
-  "buildTime": 1780514900419,
+  "version": "1.12.1",
+  "buildDate": "2026-06-10",
+  "buildTime": 1781125604784,
   "commit": "b4a51ad58bb7395884231f55fbecf535849207d9",
-  "timestamp": "2026-06-03T19:28:20.419Z"
+  "timestamp": "2026-06-10T21:06:44.784Z"
 }


### PR DESCRIPTION
## Release testing → main

Version bump und Release der aktuellen `testing`-Inhalte nach `main`.

### Versionbump
- `package.json`: `1.12.0` → **`1.12.1`**
- `Android/app/build.gradle`: `versionCode 24 → 25`, `versionName 1.12.0 → 1.12.1`
- `version.json`, `manifest.json` und Cache-Busting-Parameter in `index.html` automatisch via `npm run version:update` aktualisiert (buildDate `2026-06-10`)

### Enthaltene Änderungen seit dem letzten Release nach `main`
- `ci: pr-review.yml contents: read → write` (Autofix-Job benötigt Push-Rechte) (#307)

### Tests
- ✅ 9 Test-Suites, 190 Tests bestanden (`storage.test.js` ausgeschlossen, benötigt Firebase-Credentials)
- ✅ Pre-commit Hooks (Prettier, Version-Consistency-Check) bestanden

> Hinweis: Diese PR wird vom Branch `claude/version-bump-pr-main-yegiu6` geöffnet, der auf dem aktuellen Stand von `testing` basiert (testing + Versionbump) und nach `main` gemerged wird.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HxGRgfcNFoWJj56VtA7KA)_