### PR TITLE
fix: Firebase-Mock + timezone-agnostischer Recurring-Test (pre-existing Failures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✅ Testing
+- **Firebase-Mock in Unit-Tests:** `firebase-init.js` wird in `tests/setup.js` global gemockt —
+  `storage.test.js` (31 Tests) laufen jetzt durch statt mit `auth/invalid-api-key` zu crashen
+- **Timezone-agnostischer Recurring-Test:** `tasks.test.js` custom-Interval-Test nutzt jetzt
+  lokale `new Date(2026, 0, 22)` statt UTC-Timestamp — besteht auf allen Timezones
+
 ### 📚 Dokumentation
 - **CONTRIBUTING.md erstellt (#265):** Entwicklungs-Setup, Branch-Strategie, Commit-Konventionen,
   PR-Richtlinien, Code-Style, Testing-Anforderungen und Pre-commit-Hook-Dokumentation

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -5,6 +5,21 @@
 
 import { vi } from 'vitest';
 
+// Mock firebase-init.js globally to prevent real Firebase initialization in tests
+vi.mock('../js/modules/firebase-init.js', () => ({
+  app: {},
+  auth: {
+    currentUser: null,
+    onAuthStateChanged: vi.fn(),
+    signOut: vi.fn(),
+  },
+  db: {},
+  storage: {},
+  googleProvider: {},
+  appleProvider: {},
+  firebaseEnvironment: { env: 'testing', projectId: 'eisenhauer-testing' },
+}));
+
 // Mock localStorage
 const localStorageMock = (() => {
   let store = {};

--- a/tests/unit/tasks.test.js
+++ b/tests/unit/tasks.test.js
@@ -320,8 +320,9 @@ describe('Tasks', () => {
       expect(customResult.action).toBe('completed');
       const rawAfterCustom = getAllTasks();
       const nextCustom = rawAfterCustom[1][0];
-      // Next occurrence should be 7 days in the future
-      const expectedNextCustom = new Date('2026-01-22T00:00:00.000Z').getTime();
+      // Next occurrence should be 7 days in the future at local midnight
+      // Use local Date construction to be timezone-agnostic (implementation uses setHours)
+      const expectedNextCustom = new Date(2026, 0, 22, 0, 0, 0, 0).getTime();
       expect(nextCustom.createdAt).toBe(expectedNextCustom);
     });
 


### PR DESCRIPTION
## Problem

Zwei pre-existing Testfehler, die unabhängig von den letzten PRs existierten:

### 1. `storage.test.js` – `auth/invalid-api-key` (Suite crashed, 0/31 Tests)
`storage.js` → `auth.js` → `firebase-init.js` → `initializeApp()` mit leeren Env-Vars → Firebase wirft `auth/invalid-api-key` beim Import, bevor auch nur ein Test läuft.

**Fix:** `vi.mock('../js/modules/firebase-init.js')` global in `tests/setup.js` hinzugefügt. Gibt alle Firebase-Exports als leere Stub-Objekte zurück — kein echter Firebase-Aufruf im Test-Env.

### 2. `tasks.test.js` – Timezone-Offset (custom recurring interval)
Test setzte Zeit auf `2026-01-15T10:00:00Z` und verglich Ergebnis mit `new Date('2026-01-22T00:00:00.000Z').getTime()` (UTC-Midnight). Die Implementierung nutzt `setHours(0,0,0,0)` (lokale Zeit). In CET (UTC+1) → 1h Differenz → Assertion schlug fehl.

**Fix:** `new Date('2026-01-22T00:00:00.000Z')` → `new Date(2026, 0, 22, 0, 0, 0, 0)` (lokale Mitternacht, timezone-agnostisch).

## Ergebnis
- Vorher: 2 Suites fehlgeschlagen, 1 Test fehlgeschlagen (190 Tests gesamt, nur 189 durchgelaufen)
- Nachher: **10/10 Suites, 221/221 Tests grün** (+31 durch storage.test.js)