### PR TITLE
feat: Firebase Analytics aktivieren – DAU/WAU + PWA-vs-Web-Tracking (#318)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,16 @@ Beim App-Start wird jetzt ausschließlich der moderne PWA-Splash-Screen angezeig
 
 ## Features
 
+### Firebase Analytics (Issue #318)
+
+`logAppOpen()` wird in `initApp()` (script.js) aufgerufen und ist in `js/modules/firebase-init.js` implementiert.
+
+- Nur in **production** aktiv (`CURRENT_ENV === 'production'` + `measurementId` gesetzt)
+- Erkennt PWA vs. Browser via `window.matchMedia('(display-mode: standalone)')`
+- Loggt Event `app_open` mit Parameter `app_mode: 'standalone' | 'browser'`
+- Metriken einsehbar im **Firebase Console → Analytics → Events** (DAU/WAU/MAU unter „Active users")
+- Voraussetzung: `VITE_FIREBASE_MEASUREMENT_ID` muss als GitHub Actions Secret gesetzt sein (production environment)
+
 ### Kategorien / Kalender-Umschalter (Issue #198 + #259, PR #260)
 
 Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` oder `'business'` (siehe `filterByCategory` in `js/modules/tasks.js`). Aufgaben ohne Kategorie werden beim Filtern wie `'private'` behandelt.

--- a/js/modules/firebase-init.js
+++ b/js/modules/firebase-init.js
@@ -12,6 +12,7 @@
  */
 
 import { initializeApp } from 'firebase/app';
+import { getAnalytics, logEvent, isSupported } from 'firebase/analytics';
 import { getAuth, GoogleAuthProvider, OAuthProvider } from 'firebase/auth';
 import {
   initializeFirestore,
@@ -97,6 +98,27 @@ const appleProvider = new OAuthProvider('apple.com');
 
 // Initialize Firebase Storage
 const storage = getStorage(app);
+
+// Initialize Firebase Analytics (production only, requires measurementId)
+let analytics = null;
+if (CURRENT_ENV === 'production' && firebaseConfig.measurementId) {
+  isSupported().then((supported) => {
+    if (supported) {
+      analytics = getAnalytics(app);
+    }
+  });
+}
+
+/**
+ * Logs an app_open event with the display mode (PWA vs. browser).
+ * No-op outside production or when Analytics is not supported.
+ */
+export function logAppOpen() {
+  if (!analytics) return;
+  const isPWA =
+    window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+  logEvent(analytics, 'app_open', { app_mode: isPWA ? 'standalone' : 'browser' });
+}
 
 // Export current environment for debugging
 export const firebaseEnvironment = {

--- a/js/modules/firebase-init.js
+++ b/js/modules/firebase-init.js
@@ -100,20 +100,20 @@ const appleProvider = new OAuthProvider('apple.com');
 const storage = getStorage(app);
 
 // Initialize Firebase Analytics (production only, requires measurementId)
-let analytics = null;
-if (CURRENT_ENV === 'production' && firebaseConfig.measurementId) {
-  isSupported().then((supported) => {
-    if (supported) {
-      analytics = getAnalytics(app);
-    }
-  });
-}
+// Promise-based so logAppOpen() can await it and avoid a race condition.
+const analyticsPromise =
+  CURRENT_ENV === 'production' && firebaseConfig.measurementId
+    ? isSupported()
+        .then((supported) => (supported ? getAnalytics(app) : null))
+        .catch(() => null)
+    : Promise.resolve(null);
 
 /**
  * Logs an app_open event with the display mode (PWA vs. browser).
  * No-op outside production or when Analytics is not supported.
  */
-export function logAppOpen() {
+export async function logAppOpen() {
+  const analytics = await analyticsPromise;
   if (!analytics) return;
   const isPWA =
     window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ window.localforage = localforage;
 window.Chart = Chart;
 
 // Import Firebase services (Modular SDK V2)
-import { auth, db, storage } from './js/modules/firebase-init.js';
+import { auth, db, storage, logAppOpen } from './js/modules/firebase-init.js';
 import {
   initAuth,
   signInWithGoogle,
@@ -1102,6 +1102,8 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
  * Initialize the application
  */
 async function initApp() {
+  logAppOpen();
+
   // Initialize theme from localStorage (before anything visual loads)
   const savedTheme = localStorage.getItem(STORAGE_KEYS.DARK_MODE);
   if (savedTheme === 'true') {


### PR DESCRIPTION
## Summary

- `getAnalytics()` in `firebase-init.js` initialisiert – nur in production und nur wenn `measurementId` gesetzt ist und der Browser Analytics unterstützt (`isSupported()`)
- Neue Export-Funktion `logAppOpen()` loggt Event `app_open` mit Parameter `app_mode: 'standalone' | 'browser'` (PWA vs. regulärer Browser-Tab)
- `logAppOpen()` wird als erster Schritt in `initApp()` (script.js) aufgerufen
- CLAUDE.md: Hinweis auf Firebase Console Analytics + Secret-Voraussetzung

## Technische Details

**PWA-Erkennung:**
```js
const isPWA =
  window.matchMedia('(display-mode: standalone)').matches ||
  window.navigator.standalone === true;
```

**Kein neues npm-Paket** – `firebase/analytics` ist Teil des bereits installierten Firebase SDK.

**Production-Guard:** In `testing`/`staging`-Deployments ist Analytics stumm (kein `measurementId` in diesen Environments, + expliziter `CURRENT_ENV`-Check).

## Voraussetzung

`VITE_FIREBASE_MEASUREMENT_ID` muss als GitHub Actions Secret im `production` Environment hinterlegt sein. Der Wert `G-XXXXXXXXXX` ist im Firebase Console unter Projekteinstellungen → Allgemein → Apps zu finden.

## Test plan

- [x] 190 Unit-Tests bestehen (`npm test -- --exclude="tests/unit/storage.test.js"`)
- [x] ESLint ohne Fehler
- [x] Prettier-Format unverändert
- [ ] Nach Merge + Deploy: Firebase Console → Analytics → Events → `app_open` erscheint (24–48h Verzögerung)

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SMD8kz7skh3bgRr7gyA9y

---
_Generated by [Claude Code](https://claude.ai/code/session_016SMD8kz7skh3bgRr7gyA9y)_