### PR TITLE
fix: Recurring-Modal aufgeräumt – smooth expand + fehlende Sub-Optionen (#314)

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
             <span id="quickRecurringEnableText">🔁 Make recurring</span>
           </label>
 
-          <div id="quickRecurringOptions" class="recurring-options" style="display: none">
+          <div id="quickRecurringOptions" class="recurring-options">
             <div class="recurring-option">
               <label>
                 <input type="radio" name="quickRecurringType" value="daily" checked />
@@ -302,7 +302,7 @@
                 <input type="radio" name="quickRecurringType" value="weekly" />
                 <span id="quickRecurringWeekly">Weekly</span>
               </label>
-              <div id="quickWeekdaysContainer" class="weekdays-container" style="display: none">
+              <div id="quickWeekdaysContainer" class="weekdays-container">
                 <label
                   ><input type="checkbox" class="weekday-check" value="1" />
                   <span id="quickMon">Mon</span></label
@@ -338,7 +338,7 @@
                 <input type="radio" name="quickRecurringType" value="monthly" />
                 <span id="quickRecurringMonthly">Monthly</span>
               </label>
-              <div id="quickMonthDayContainer" style="display: none">
+              <div id="quickMonthDayContainer">
                 <input
                   type="number"
                   id="quickMonthDay"

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -1187,7 +1187,10 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   // Reset modal
   quickAddInput.value = '';
   quickRecurringEnabled.checked = false;
-  quickRecurringOptions.style.display = 'none';
+  quickRecurringOptions.classList.remove('expanded');
+  document.getElementById('quickWeekdaysContainer')?.classList.remove('expanded');
+  document.getElementById('quickMonthDayContainer')?.classList.remove('expanded');
+  document.querySelector('input[name="quickRecurringType"][value="daily"]').checked = true;
 
   // Reset due date
   const dueDateInput = document.getElementById('quickAddDueDate');
@@ -1249,6 +1252,18 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   if (quickRecurringDaily) quickRecurringDaily.textContent = lang.recurring.daily;
   if (quickRecurringWeekly) quickRecurringWeekly.textContent = lang.recurring.weekly;
   if (quickRecurringMonthly) quickRecurringMonthly.textContent = lang.recurring.monthly;
+
+  // Wire up sub-option visibility for recurring type (missing since legacy migration)
+  document.querySelectorAll('input[name="quickRecurringType"]').forEach((radio) => {
+    radio.onchange = () => {
+      document
+        .getElementById('quickWeekdaysContainer')
+        ?.classList.toggle('expanded', radio.value === 'weekly');
+      document
+        .getElementById('quickMonthDayContainer')
+        ?.classList.toggle('expanded', radio.value === 'monthly');
+    };
+  });
 
   // Show modal
   quickAddModal.style.display = 'flex';

--- a/script.js
+++ b/script.js
@@ -959,12 +959,16 @@ function setupEventListeners() {
     });
   }
 
-  // Quick add recurring toggle (Fix for Issue #76)
+  // Quick add recurring toggle (Fix for Issue #76, smooth expand #314)
   const quickRecurringEnabled = document.getElementById('quickRecurringEnabled');
   const quickRecurringOptions = document.getElementById('quickRecurringOptions');
   if (quickRecurringEnabled && quickRecurringOptions) {
     quickRecurringEnabled.addEventListener('change', () => {
-      quickRecurringOptions.style.display = quickRecurringEnabled.checked ? 'block' : 'none';
+      quickRecurringOptions.classList.toggle('expanded', quickRecurringEnabled.checked);
+      if (!quickRecurringEnabled.checked) {
+        document.getElementById('quickWeekdaysContainer')?.classList.remove('expanded');
+        document.getElementById('quickMonthDayContainer')?.classList.remove('expanded');
+      }
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -1532,6 +1532,28 @@ body.dark-mode .search-highlight {
   margin-bottom: 10px;
 }
 
+.recurring-config-quick .recurring-options {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.28s ease-out;
+}
+
+.recurring-config-quick .recurring-options.expanded {
+  max-height: 350px;
+}
+
+.recurring-config-quick .weekdays-container,
+.recurring-config-quick #quickMonthDayContainer {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.2s ease-out;
+}
+
+.recurring-config-quick .weekdays-container.expanded,
+.recurring-config-quick #quickMonthDayContainer.expanded {
+  max-height: 80px;
+}
+
 .recurring-enable {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Problem (Issue #314)

Das "Erstellen"-Fenster wirkte unübersichtlich. Dazu kam ein stiller Bug: Wochentag-Checkboxen und Monatstag-Feld für wiederkehrende Aufgaben waren permanent ausgeblendet — der Radio-Change-Listener existierte nur im Legacy-Archiv und wurde nie in die aktuelle Codebasis migriert.

## Änderungen

### Bug-Fix: fehlende Radio-Listener
- `openQuickAddModal()` (ui.js) registriert jetzt `onchange`-Listener auf den Typ-Radios
- Bei „Wöchentlich": Wochentag-Checkboxen einblenden
- Bei „Monatlich": Monatstag-Eingabe einblenden

### UX: smooth expand statt harter display-Wechsel
- CSS `max-height`-Transition für `.recurring-config-quick .recurring-options` (0 → 350px, 280ms ease-out)
- CSS `max-height`-Transition für Weekdays-Container und Monatstag-Container (0 → 80px, 200ms ease-out)
- `style="display: none"` aus HTML entfernt → CSS übernimmt den Collapsed-State
- JS-Listener nutzen `.classList.toggle('expanded', ...)` statt `style.display`

### Reset beim Öffnen
- Beim erneuten Öffnen werden alle Sub-Optionen collapsed zurückgesetzt
- Radio-Auswahl zurück auf „Daily"

## Test plan

- [x] 190 Unit-Tests grün
- [x] ESLint + Prettier sauber
- [ ] Manuell: Modal öffnen → Haken bei „wiederkehrend" → smooth expand
- [ ] Manuell: „Wöchentlich" wählen → Wochentag-Checkboxen erscheinen
- [ ] Manuell: „Monatlich" wählen → Monatstag-Eingabe erscheint
- [ ] Manuell: Haken entfernen → alles klappt zusammen

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SMD8kz7skh3bgRr7gyA9y

---
_Generated by [Claude Code](https://claude.ai/code/session_016SMD8kz7skh3bgRr7gyA9y)_