### PR TITLE
fix(csp): Google-Login per signInWithPopup wieder erlauben

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <!-- Note: frame-ancestors is not supported via meta, clickjacking protection requires HTTP header -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.firebasestorage.app wss://*.firebaseio.com https://*.ingest.sentry.io; img-src 'self' data: blob:; font-src 'self'; frame-src https://*.firebaseapp.com; base-uri 'self'; form-action 'self';"
+      content="default-src 'self'; script-src 'self' https://apis.google.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.firebasestorage.app wss://*.firebaseio.com https://*.ingest.sentry.io; img-src 'self' data: blob:; font-src 'self'; frame-src https://*.firebaseapp.com https://apis.google.com https://accounts.google.com; base-uri 'self'; form-action 'self';"
     />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 


### PR DESCRIPTION
## Problem
Beim Aufruf der Webversion erscheint in der Konsole:
> Refused to load `https://apis.google.com/js/api.js` because it does not appear in the script-src directive of the Content Security Policy.

`https://apis.google.com/js/api.js` wird von Firebase Auth für `signInWithPopup(GoogleAuthProvider)` geladen. Da Google die **primäre Login-Methode** ist (sichtbarer Button `googleSignInBtn`; Apple ist `display:none`), konnten sich **neue Nutzer nicht anmelden**.

**Warum es nicht auffiel:** Bestehende Sessions sind im Browser gecached → Firestore-Sync (Tasks zwischen Telefon und Web) läuft über `connect-src https://*.googleapis.com` und war nie betroffen. Nur ein *frischer* Google-Login (Logout / neues Gerät / neuer Nutzer) schlug fehl.

## Änderung
Minimale CSP-Erweiterung in `index.html`:
- `script-src`: `+ https://apis.google.com`
- `frame-src`: `+ https://apis.google.com https://accounts.google.com` (Google-Auth-Popup-Iframe)

## Bewusst NICHT enthalten
- `googletagmanager.com` (Analytics/gtag) bleibt geblockt. Analytics ist aus Datenschutzgründen nicht erwünscht; die `measurementId` wird in einem **separaten PR** entfernt (Issue #320 wird dort rückgängig gemacht; Besucherzählung künftig via GitHub Pages Insights).
- Die Asset-404s (`version.json`, Icons unter `assets/`) folgen in einem **dritten separaten PR**.

## Test
Nach Deploy: ausloggen → "Sign in with Google" → Popup muss laden und Login durchlaufen. Konsole darf keine CSP-Verweigerung für `apis.google.com` mehr zeigen.