### PR TITLE
chore: Firebase Analytics entfernen (#320 rückgängig)

### DIFF
--- a/.env-development.example
+++ b/.env-development.example
@@ -8,4 +8,3 @@ VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
 VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-storage-bucket>
 VITE_FIREBASE_MESSAGING_SENDER_ID=<your-firebase-messaging-sender-id>
 VITE_FIREBASE_APP_ID=<your-firebase-app-id>
-VITE_FIREBASE_MEASUREMENT_ID=<your-firebase-measurement-id>

--- a/.env-production.example
+++ b/.env-production.example
@@ -8,4 +8,3 @@ VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
 VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-storage-bucket>
 VITE_FIREBASE_MESSAGING_SENDER_ID=<your-firebase-messaging-sender-id>
 VITE_FIREBASE_APP_ID=<your-firebase-app-id>
-VITE_FIREBASE_MEASUREMENT_ID=<your-firebase-measurement-id>

--- a/.env-staging.example
+++ b/.env-staging.example
@@ -8,4 +8,3 @@ VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
 VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-storage-bucket>
 VITE_FIREBASE_MESSAGING_SENDER_ID=<your-firebase-messaging-sender-id>
 VITE_FIREBASE_APP_ID=<your-firebase-app-id>
-VITE_FIREBASE_MEASUREMENT_ID=<your-firebase-measurement-id>

--- a/.env-testing.example
+++ b/.env-testing.example
@@ -8,4 +8,3 @@ VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
 VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-storage-bucket>
 VITE_FIREBASE_MESSAGING_SENDER_ID=<your-firebase-messaging-sender-id>
 VITE_FIREBASE_APP_ID=<your-firebase-app-id>
-VITE_FIREBASE_MEASUREMENT_ID=<your-firebase-measurement-id>

--- a/.github/workflows/deploy-unified.yml
+++ b/.github/workflows/deploy-unified.yml
@@ -100,7 +100,6 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Backup-Datum aktualisiert (#257):** `docs/last-backup.txt` auf 2026-06-15 gesetzt
 
 ### 🔧 Maintenance
+- **Firebase Analytics entfernt (#320 rückgängig):** Aus Datenschutzgründen wird keine
+  Firebase/Google Analytics mehr genutzt — `getAnalytics`/`logEvent`/`isSupported`-Import,
+  `analyticsPromise`, `logAppOpen()`, `measurementId` und das
+  `VITE_FIREBASE_MEASUREMENT_ID`-Secret entfernt. Besucherzahlen werden stattdessen
+  über GitHub Pages Insights erfasst.
 - **Dependency Updates (#256):** patch/minor Updates aller Abhängigkeiten
   (`firebase`, `vite`, `vitest`, `@vitest/*`, `@playwright/test`, `eslint`,
   `@typescript-eslint/*`, `prettier`, `globals`, `vite-plugin-pwa`, `happy-dom`)

--- a/js/modules/firebase-init.js
+++ b/js/modules/firebase-init.js
@@ -12,7 +12,6 @@
  */
 
 import { initializeApp } from 'firebase/app';
-import { getAnalytics, logEvent, isSupported } from 'firebase/analytics';
 import { getAuth, GoogleAuthProvider, OAuthProvider } from 'firebase/auth';
 import {
   initializeFirestore,
@@ -33,7 +32,6 @@ const firebaseConfig = {
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
 // Safeguard: Verify Firebase project matches expected environment
@@ -99,26 +97,8 @@ const appleProvider = new OAuthProvider('apple.com');
 // Initialize Firebase Storage
 const storage = getStorage(app);
 
-// Initialize Firebase Analytics (production only, requires measurementId)
-// Promise-based so logAppOpen() can await it and avoid a race condition.
-const analyticsPromise =
-  CURRENT_ENV === 'production' && firebaseConfig.measurementId
-    ? isSupported()
-        .then((supported) => (supported ? getAnalytics(app) : null))
-        .catch(() => null)
-    : Promise.resolve(null);
-
-/**
- * Logs an app_open event with the display mode (PWA vs. browser).
- * No-op outside production or when Analytics is not supported.
- */
-export async function logAppOpen() {
-  const analytics = await analyticsPromise;
-  if (!analytics) return;
-  const isPWA =
-    window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
-  logEvent(analytics, 'app_open', { app_mode: isPWA ? 'standalone' : 'browser' });
-}
+// Note: Firebase Analytics / Google Analytics is intentionally NOT used
+// (privacy). Visitor counts are tracked via GitHub Pages Insights instead.
 
 // Export current environment for debugging
 export const firebaseEnvironment = {

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ window.localforage = localforage;
 window.Chart = Chart;
 
 // Import Firebase services (Modular SDK V2)
-import { auth, db, storage, logAppOpen } from './js/modules/firebase-init.js';
+import { auth, db, storage } from './js/modules/firebase-init.js';
 import {
   initAuth,
   signInWithGoogle,
@@ -1108,7 +1108,6 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
  */
 async function initApp() {
   initSentry();
-  logAppOpen();
 
   // Initialize theme from localStorage (before anything visual loads)
   const savedTheme = localStorage.getItem(STORAGE_KEYS.DARK_MODE);


### PR DESCRIPTION
## Was

Entfernt die mit PR #319/#320 eingeführte Firebase Analytics-Integration vollständig — aus Datenschutzgründen wird **keine** Firebase/Google Analytics mehr genutzt.

## Änderungen

- **`js/modules/firebase-init.js`**: `getAnalytics`/`logEvent`/`isSupported`-Import, `analyticsPromise`, `logAppOpen()` und `measurementId` aus der Config entfernt. Erklärender Kommentar ergänzt.
- **`script.js`**: `logAppOpen`-Import + Aufruf in `initApp()` entfernt.
- **`.github/workflows/deploy-unified.yml`**: `VITE_FIREBASE_MEASUREMENT_ID`-Secret-Injection entfernt.
- **`.env-*.example`** (4 Dateien): `VITE_FIREBASE_MEASUREMENT_ID`-Zeile entfernt.

> Besucherzahlen werden stattdessen über **GitHub Pages Insights** erfasst.

## Verifikation

- ✅ Lint: 0 Errors (2 pre-existing Warnings in `update-version.js`)
- ✅ Tests: 190 passing (9 Suites, excl. `storage.test.js`)
- ✅ Build: erfolgreich

## Hinweise

- `@firebase/analytics` bleibt als transitive Sub-Dependency des `firebase`-Meta-Pakets im `package-lock.json` — kein eigener Eintrag in `package.json`, daher nicht angefasst.
- Das GitHub-Actions-Secret `FIREBASE_MEASUREMENT_ID` kann nach dem Merge aus dem Repo-Setting entfernt werden (manuell, nicht Teil dieses PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)