### PR TITLE
fix: stabile Task-IDs gegen Quadranten-Duplikate &amp; Einfrieren

### DIFF
--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -175,14 +175,28 @@ export async function loadUserTasks(userId, db) {
     // Initialize empty tasks structure
     const tasks = { 1: [], 2: [], 3: [], 4: [], 5: [] };
 
+    // Guard against the same logical task appearing in more than one quadrant.
+    // Historically this could happen when an unstable float ID drifted between
+    // Number and String and a failed move left a stray duplicate document
+    // behind, so the task rendered in several quadrants at once.
+    const seenIds = new Set();
+
     // Load tasks from Firestore
     snapshot.forEach((docSnap) => {
       const task = docSnap.data();
-      task.id = docSnap.id; // Use Firestore document ID
+      task.id = String(docSnap.id); // Firestore document ID is the source of truth
 
-      // Ensure segment exists
-      if (tasks[task.segment]) {
-        tasks[task.segment].push(task);
+      // Skip duplicates (defensive: a task must live in exactly one quadrant)
+      if (seenIds.has(task.id)) {
+        return;
+      }
+
+      // Normalise the segment so a string/number mismatch still routes correctly
+      const segment = Number(task.segment);
+      if (tasks[segment]) {
+        task.segment = segment;
+        seenIds.add(task.id);
+        tasks[segment].push(task);
       }
     });
 

--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -18,6 +18,44 @@ export let tasks = {
 export let currentTask = null;
 
 /**
+ * Generate a stable, collision-free task ID.
+ *
+ * The previous scheme (`Date.now() + Math.random()`) produced a floating point
+ * number that (a) only had ~12 bits of fractional resolution at the current
+ * timestamp magnitude (collision risk when several tasks are created in the
+ * same millisecond) and (b) was stored as a Firestore document ID via
+ * `.toString()` and then read back as a *string* on load. That made the task
+ * identity drift between Number and String, so strict `===` lookups in
+ * move/toggle/delete/reorder could silently miss the task and leave duplicate
+ * documents behind (the same task showing up in several quadrants).
+ *
+ * A UUID string is stable across create → save → reload and never collides.
+ * @returns {string} Unique task ID
+ */
+export function generateTaskId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (older browsers/tests)
+  return `task-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Compare two task IDs irrespective of their type.
+ *
+ * IDs created in-memory may be strings while IDs loaded from Firestore are the
+ * (string) document IDs; legacy data may even hold numbers. Comparing them as
+ * strings guarantees a move/toggle/delete always finds its task instead of
+ * silently failing and corrupting state.
+ * @param {string|number} a
+ * @param {string|number} b
+ * @returns {boolean}
+ */
+export function sameTaskId(a, b) {
+  return String(a) === String(b);
+}
+
+/**
  * Set current task (used by modal)
  */
 export function setCurrentTask(task) {
@@ -122,7 +160,7 @@ function createTaskObject(
   category = null
 ) {
   const task = {
-    id: Date.now() + Math.random(), // Add random to avoid ID collisions
+    id: generateTaskId(), // Stable, collision-free string ID (see generateTaskId)
     text: taskText,
     segment: segmentId,
     checked: false,
@@ -233,7 +271,7 @@ export function restoreTask(taskObject, saveCallback = null) {
  * @returns {boolean} True if task was deleted
  */
 export function deleteTask(taskId, segmentId, deleteCallback = null) {
-  const taskIndex = tasks[segmentId].findIndex((t) => t.id === taskId);
+  const taskIndex = tasks[segmentId].findIndex((t) => sameTaskId(t.id, taskId));
   if (taskIndex === -1) return false;
 
   tasks[segmentId].splice(taskIndex, 1);
@@ -266,7 +304,7 @@ export function moveTask(taskId, fromSegment, toSegment, saveCallback = null) {
     throw new Error('Task ID cannot be null or undefined');
   }
 
-  const taskIndex = tasks[fromSegment].findIndex((t) => t.id === taskId);
+  const taskIndex = tasks[fromSegment].findIndex((t) => sameTaskId(t.id, taskId));
   if (taskIndex === -1) return null;
 
   const task = tasks[fromSegment][taskIndex];
@@ -334,7 +372,7 @@ export function reorderTask(taskId, segment, newIndex, saveCallback = null) {
     throw new Error('New index must be a non-negative integer');
   }
 
-  const taskIndex = tasks[segment].findIndex((t) => t.id === taskId);
+  const taskIndex = tasks[segment].findIndex((t) => sameTaskId(t.id, taskId));
   if (taskIndex === -1) return null;
 
   // If task is already at the target position, no need to reorder
@@ -363,7 +401,7 @@ export function reorderTask(taskId, segment, newIndex, saveCallback = null) {
  * @returns {object|null} Result object with task and action info
  */
 export function toggleTask(taskId, segmentId, saveCallback = null) {
-  const taskIndex = tasks[segmentId].findIndex((t) => t.id === taskId);
+  const taskIndex = tasks[segmentId].findIndex((t) => sameTaskId(t.id, taskId));
   if (taskIndex === -1) return null;
 
   const task = tasks[segmentId][taskIndex];
@@ -467,7 +505,7 @@ export function getTasks(segmentId) {
  * @returns {object|null} Task object or null if not found
  */
 export function getTask(taskId, segmentId) {
-  return tasks[segmentId].find((t) => t.id === taskId) || null;
+  return tasks[segmentId].find((t) => sameTaskId(t.id, taskId)) || null;
 }
 
 /**
@@ -517,7 +555,7 @@ export function getTotalTaskCount() {
  * @returns {object|null} Updated task or null if not found
  */
 export function updateTask(taskId, segmentId, updates) {
-  const task = tasks[segmentId].find((t) => t.id === taskId);
+  const task = tasks[segmentId].find((t) => sameTaskId(t.id, taskId));
   if (!task) return null;
 
   Object.assign(task, updates);

--- a/script.js
+++ b/script.js
@@ -54,6 +54,7 @@ import {
   reorderTask,
   applySmartRules,
   filterByCategory,
+  sameTaskId,
 } from './js/modules/tasks.js';
 import {
   initStorage,
@@ -213,7 +214,7 @@ function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null
  */
 function handleDeleteTask(taskId, segment) {
   // Find the task to check if it's recurring
-  const task = tasks[segment].find((t) => t.id === taskId);
+  const task = tasks[segment].find((t) => sameTaskId(t.id, taskId));
   if (!task) return;
 
   // If it's a recurring task, show options for deletion scope
@@ -243,7 +244,7 @@ function handleDeleteTask(taskId, segment) {
     });
   } else {
     // Non-recurring task - delete immediately
-    const deletedTask = tasks[segment].find((t) => t.id === taskId);
+    const deletedTask = tasks[segment].find((t) => sameTaskId(t.id, taskId));
     deleteTask(taskId, segment);
     syncDelete(taskId, segment);
     renderTasksWithCallbacks();
@@ -326,7 +327,7 @@ function handleMoveTask(taskId, fromSegment, toSegment) {
  */
 function handleReorderTask(taskId, segment, direction) {
   // Find current index
-  const currentIndex = tasks[segment].findIndex((t) => t.id === taskId);
+  const currentIndex = tasks[segment].findIndex((t) => sameTaskId(t.id, taskId));
   if (currentIndex === -1) return;
 
   // Calculate new index based on direction
@@ -366,7 +367,7 @@ function handleReorderTask(taskId, segment, direction) {
  */
 function handleToggleTask(taskId, segment) {
   // Store previous state for undo
-  const task = tasks[segment]?.find((t) => t.id === taskId);
+  const task = tasks[segment]?.find((t) => sameTaskId(t.id, taskId));
   const wasChecked = task ? task.checked : false;
 
   const result = toggleTask(taskId, segment);
@@ -410,7 +411,7 @@ function handleEditRecurring(task) {
     (taskId, newRecurringConfig) => {
       // Find the task
       for (const segment in tasks) {
-        const taskIndex = tasks[segment].findIndex((t) => t.id === taskId);
+        const taskIndex = tasks[segment].findIndex((t) => sameTaskId(t.id, taskId));
         if (taskIndex !== -1) {
           if (newRecurringConfig === 'DELETE') {
             // Delete task permanently

--- a/tests/unit/tasks.test.js
+++ b/tests/unit/tasks.test.js
@@ -27,6 +27,8 @@ import {
   clearCompletedTasks,
   getRecurringDescription,
   applySmartRules,
+  generateTaskId,
+  sameTaskId,
 } from '../../js/modules/tasks.js';
 
 const createEmptyTasks = () => ({
@@ -525,6 +527,49 @@ describe('Tasks', () => {
       const clearedTasks = applySmartRules(tasksToProcess, false);
       expect(clearedTasks[1][0].isUrgent).toBeUndefined();
       expect(clearedTasks[1][1].isUrgent).toBeUndefined();
+    });
+  });
+
+  describe('task identity (generateTaskId / sameTaskId)', () => {
+    it('should generate unique string IDs (no float collisions)', () => {
+      const ids = new Set();
+      for (let i = 0; i < 1000; i++) {
+        const id = generateTaskId();
+        expect(typeof id).toBe('string');
+        ids.add(id);
+      }
+      // All 1000 IDs must be distinct, even when created in the same tick
+      expect(ids.size).toBe(1000);
+    });
+
+    it('addTaskToSegment assigns a stable string ID', () => {
+      const task = addTaskToSegment('Stable id', SEGMENTS.DO);
+      expect(typeof task.id).toBe('string');
+      expect(task.id.length).toBeGreaterThan(0);
+    });
+
+    it('sameTaskId compares ids irrespective of type', () => {
+      expect(sameTaskId(1, 1)).toBe(true);
+      expect(sameTaskId(1, '1')).toBe(true); // Number (in-memory) vs String (after reload)
+      expect(sameTaskId('abc', 'abc')).toBe(true);
+      expect(sameTaskId(1, 2)).toBe(false);
+      expect(sameTaskId('abc', 'abcd')).toBe(false);
+    });
+
+    it('moveTask finds a task even when the lookup id type differs', () => {
+      // Simulates the real bug: task was loaded with a string id, but the
+      // drag layer passes the numeric variant (or vice versa).
+      setAllTasks({
+        ...createEmptyTasks(),
+        [SEGMENTS.DO]: [{ id: '12345', text: 'Drifted id', segment: SEGMENTS.DO, checked: false }],
+      });
+
+      const moved = moveTask(12345, SEGMENTS.DO, SEGMENTS.SCHEDULE);
+
+      expect(moved).not.toBeNull();
+      // Original must be removed (no duplicate left behind in another quadrant)
+      expect(getAllTasks()[SEGMENTS.DO]).toHaveLength(0);
+      expect(getAllTasks()[SEGMENTS.SCHEDULE]).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Problem

Beim Anlegen mehrerer Aufgaben konnte **eine Aufgabe in mehreren/allen Matrix-Quadranten gleichzeitig** (Do/Schedule/Delegate/Ignore/Done) auftauchen, und die App fror ein.

## Ursachenanalyse

Das Rendering iteriert stumpf die Arrays `tasks[1..5]` (`ui.js` `renderAllTasks`/`renderSegment`). Eine Aufgabe erscheint also in mehreren Quadranten, wenn sie **physisch mehrfach gespeichert** ist – ein Datenproblem, kein reiner Anzeigefehler. Wurzel war die **instabile Task-Identität**:

- IDs wurden als `Date.now() + Math.random()` (Float) erzeugt → bei der aktuellen Timestamp-Größenordnung nur ~12 Bit Nachkomma-Auflösung (4096 Buckets/ms), also **Kollisionsrisiko** bei schneller Eingabe.
- Der Float wurde via `.toString()` als **Firestore-Dokument-ID** gespeichert und beim Laden als **String** zurückgeschrieben (`task.id = docSnap.id`).
- Alle CRUD-Lookups verglichen **strikt** (`t.id === taskId`). Nach einem Reload matchte `Number` (frisch erzeugt) nicht mehr mit `String` (geladen). Ein dadurch fehlgeschlagener `moveTask` ließ das Original liegen → **Geister-Duplikate** über Segmente.

Das Einfrieren ist kein Render-Loop (der Pfad ist seit #298 pro Segment/Task mit `try/catch` abgesichert), sondern Folge des inkonsistenten Zustands (u. a. der sequentielle `saveAllTasks`-Pfad über alle – teils duplizierten – Tasks).

## Änderungen

- **`generateTaskId()`** – stabile, kollisionsfreie String-ID (`crypto.randomUUID()` mit Fallback) statt Float.
- **`sameTaskId()`** – typsicherer ID-Vergleich (`String(a) === String(b)`); ersetzt alle strikten Lookups in `tasks.js` und `script.js`, sodass Number↔String nie mehr auseinanderläuft.
- **`loadUserTasks`** – ID als String normalisieren, `segment` robust casten und **Duplikate (gleiche ID in mehreren Quadranten) beim Laden herausfiltern** (Defense-in-depth für bereits korrupte Daten).
- **Unit-Tests** – ID-Eindeutigkeit, typunabhängiger Vergleich und Move bei abweichendem ID-Typ.

## Tests

- `vitest run --exclude="tests/unit/storage.test.js"` → **194 Tests grün** (inkl. 4 neuer).
- ESLint: 0 Errors.

## Hinweis / möglicher Follow-up

Der `saveAllTasks()`-Pfad (`script.js`) speichert weiterhin sequentiell `await` über alle Tasks – bei sehr vielen Aufgaben auf wackliger Verbindung weiterhin ein potenzieller Performance-Engpass. Bewusst außerhalb des Scopes dieses Fixes gelassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3zigaRfiLpnZ5ANeU3Kwf)_