### PR TITLE
fix(ux): Fokus-Mode blendet Done-Segment aus + Q4-Detox mit Beschreibung

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,6 +534,10 @@
         <!-- Q4 Detox -->
         <div class="settings-section">
           <h4 id="q4DetoxTitle" class="settings-section-title">Q4-DETOX</h4>
+          <p class="settings-info" id="q4DetoxDesc">
+            Archiviert alle Aufgaben aus „Später!" (Q4) auf einmal – ideal, um nicht dringende und
+            unwichtige Aufgaben aufzuräumen.
+          </p>
           <button id="q4DetoxBtn" class="btn">Q4 aufräumen</button>
         </div>
 

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -52,6 +52,8 @@ export const translations = {
       about: 'Über',
       q4Detox: 'Q4-DETOX',
       q4DetoxBtn: 'Q4 aufräumen',
+      q4DetoxDesc:
+        'Archiviert alle Aufgaben aus „Später!" (Q4) auf einmal – ideal, um nicht dringende und unwichtige Aufgaben aufzuräumen.',
       q4DetoxConfirm: 'Alle Aufgaben aus "Später!" archivieren?',
       q4DetoxSuccess: 'Q4-Aufgaben archiviert!',
       q4DetoxEmpty: 'Keine Q4-Aufgaben vorhanden',
@@ -223,6 +225,8 @@ export const translations = {
       about: 'About',
       q4Detox: 'Q4 DETOX',
       q4DetoxBtn: 'Clear Q4',
+      q4DetoxDesc:
+        'Archives all tasks from "Ignore!" (Q4) at once – ideal for clearing out tasks that are neither urgent nor important.',
       q4DetoxConfirm: 'Archive all tasks from "Ignore!"?',
       q4DetoxSuccess: 'Q4 tasks archived!',
       q4DetoxEmpty: 'No Q4 tasks to archive',
@@ -683,6 +687,22 @@ export function updateLanguageUI(renderAllTasksCallback) {
   const smartFunctionsDesc = document.getElementById('smartFunctionsDesc');
   if (smartFunctionsDesc) {
     smartFunctionsDesc.textContent = lang.personalize.smartFunctionsDesc;
+  }
+
+  // Update Q4-Detox section (title, description, button)
+  const q4DetoxTitle = document.getElementById('q4DetoxTitle');
+  if (q4DetoxTitle) {
+    q4DetoxTitle.textContent = lang.settings.q4Detox;
+  }
+
+  const q4DetoxDesc = document.getElementById('q4DetoxDesc');
+  if (q4DetoxDesc) {
+    q4DetoxDesc.textContent = lang.settings.q4DetoxDesc;
+  }
+
+  const q4DetoxBtn = document.getElementById('q4DetoxBtn');
+  if (q4DetoxBtn) {
+    q4DetoxBtn.textContent = lang.settings.q4DetoxBtn;
   }
 
   // Update Category Filter section in Personalize Modal

--- a/style.css
+++ b/style.css
@@ -2733,7 +2733,8 @@ body.dark-mode .undo-toast {
 
 /* Focus Mode Active - Hide Q3 and Q4 */
 body.focus-mode .segment[data-segment='3'],
-body.focus-mode .segment[data-segment='4'] {
+body.focus-mode .segment[data-segment='4'],
+body.focus-mode .segment[data-segment='5'] {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- Fokus-Mode blendet jetzt auch Segment 5 (Done/Erledigt) aus — bisher wurden nur Q3 und Q4 ausgeblendet
- Q4-Detox-Sektion erhält einen Beschreibungstext (DE + EN) der erklärt, was die Funktion tut
- `updateLanguageUI` aktualisiert Titel, Beschreibung und Button des Q4-Detox-Abschnitts bei Sprachwechsel

## Test plan

- [ ] Fokus-Mode aktivieren → Q3, Q4 und Done-Segment nicht mehr sichtbar
- [ ] Fokus-Mode deaktivieren → alle Segmente wieder sichtbar
- [ ] Einstellungen öffnen → Q4-Detox-Abschnitt zeigt Beschreibungstext
- [ ] Sprache wechseln (DE ↔ EN) → Beschreibungstext wechselt korrekt mit

🤖 Generated with [Claude Code](https://claude.com/claude-code)