### PR TITLE
fix: Kategorie-Filter-Toggle + (BETA) bei Erinnerungen

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,6 +700,10 @@
           <h4 class="settings-section-title" id="personalizeCategoryFilterTitle">
             KATEGORIE-FILTER
           </h4>
+          <label class="smart-functions-toggle">
+            <input type="checkbox" id="categoryFilterToggle" />
+            <span id="categoryFilterLabel">Kategorie-Filter aktivieren</span>
+          </label>
           <p class="settings-info" id="categoryFilterDesc">
             Über den Umschalter im Kopf zwischen Alle, Privat und Beruflich wechseln. Neue Aufgaben
             werden der aktiven Kategorie zugeordnet.
@@ -710,7 +714,7 @@
 
         <!-- Reminders Settings -->
         <div class="settings-section">
-          <h4 class="settings-section-title" id="personalizeRemindersTitle">ERINNERUNGEN</h4>
+          <h4 class="settings-section-title" id="personalizeRemindersTitle">ERINNERUNGEN (BETA)</h4>
           <label class="smart-functions-toggle">
             <input type="checkbox" id="remindersToggle" />
             <span id="remindersLabel">Erinnerungen aktivieren</span>

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -73,9 +73,10 @@ export const translations = {
       smartFunctionsDesc:
         'Automatisch Aufgaben als dringend markieren, wenn sie in 3 Tagen fällig sind. Aktiviert auch Quadranten-Vorschläge und Matrix-Statistiken.',
       categoryFilter: 'KATEGORIE-FILTER',
+      categoryFilterLabel: 'Kategorie-Filter aktivieren',
       categoryFilterDesc:
         'Über den Umschalter im Kopf zwischen Alle, Privat und Beruflich wechseln. Neue Aufgaben werden der aktiven Kategorie zugeordnet.',
-      reminders: 'ERINNERUNGEN',
+      reminders: 'ERINNERUNGEN (BETA)',
       remindersLabel: 'Erinnerungen aktivieren',
       remindersDesc: 'Native Benachrichtigungen für Aufgaben mit Fälligkeitsdatum',
       remindersBefore: 'Erinnerung',
@@ -263,9 +264,10 @@ export const translations = {
       smartFunctionsDesc:
         'Automatically mark tasks as urgent when due within 3 days. Also enables quadrant suggestions and matrix statistics.',
       categoryFilter: 'CATEGORY FILTER',
+      categoryFilterLabel: 'Enable Category Filter',
       categoryFilterDesc:
         'Switch between All, Private and Business using the header switcher. New tasks are assigned to the active category.',
-      reminders: 'REMINDERS',
+      reminders: 'REMINDERS (BETA)',
       remindersLabel: 'Enable Reminders',
       remindersDesc: 'Native notifications for tasks with due dates',
       remindersBefore: 'Remind me',
@@ -754,6 +756,11 @@ export function updateLanguageUI(renderAllTasksCallback) {
   const personalizeCategoryFilterTitle = document.getElementById('personalizeCategoryFilterTitle');
   if (personalizeCategoryFilterTitle) {
     personalizeCategoryFilterTitle.textContent = lang.personalize.categoryFilter;
+  }
+
+  const categoryFilterLabel = document.getElementById('categoryFilterLabel');
+  if (categoryFilterLabel) {
+    categoryFilterLabel.textContent = lang.personalize.categoryFilterLabel;
   }
 
   const categoryFilterDesc = document.getElementById('categoryFilterDesc');

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -742,6 +742,12 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     smartFunctionsToggle.checked = localStorage.getItem('smartFunctionsEnabled') === 'true';
   }
 
+  // Category filter toggle reflects whether the header switcher is enabled
+  const categoryFilterToggle = document.getElementById('categoryFilterToggle');
+  if (categoryFilterToggle) {
+    categoryFilterToggle.checked = localStorage.getItem('categoryFilterEnabled') === 'true';
+  }
+
   // Update reminders toggle + dropdown state
   const remindersToggle = document.getElementById('remindersToggle');
   const remindersDaysContainer = document.getElementById('remindersDaysContainer');
@@ -815,6 +821,20 @@ export function openPersonalizeModal(currentLanguage = 'en') {
       localStorage.setItem('smartFunctionsEnabled', isEnabled.toString());
 
       // Trigger re-render if callback is provided
+      if (window.renderTasksCallback) {
+        window.renderTasksCallback();
+      }
+      return;
+    }
+
+    // Handle category filter toggle (show/hide the header switcher)
+    if (target.id === 'categoryFilterToggle') {
+      const isEnabled = target.checked;
+      localStorage.setItem('categoryFilterEnabled', isEnabled.toString());
+
+      if (window.updateCategorySwitcherVisibility) {
+        window.updateCategorySwitcherVisibility();
+      }
       if (window.renderTasksCallback) {
         window.renderTasksCallback();
       }
@@ -1203,10 +1223,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
     dueDateInput.value = '';
   }
 
-  // Show category selector and preselect the active calendar (Privat/Beruflich)
+  // Show category selector only when the category filter feature is enabled,
+  // and preselect the active calendar (Privat/Beruflich)
   const categoryConfig = document.getElementById('quickAddCategoryConfig');
   if (categoryConfig) {
-    categoryConfig.style.display = '';
+    const categoryFilterEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
+    categoryConfig.style.display = categoryFilterEnabled ? '' : 'none';
     // Preselect the active calendar so new tasks land in the current view;
     // the user can still override it (incl. "Keine") per task.
     const activeCategory = localStorage.getItem('categoryFilter') || '';

--- a/script.js
+++ b/script.js
@@ -479,8 +479,10 @@ function renderTasksWithCallbacks() {
       : tasks;
 
     // Apply category filter based on the active calendar switcher
+    // (only when the category filter feature is enabled in Personalize)
+    const categoryFilterEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
     const categoryFilter = localStorage.getItem('categoryFilter');
-    if (categoryFilter) {
+    if (categoryFilterEnabled && categoryFilter) {
       tasksToRender = filterByCategory(tasksToRender, categoryFilter);
     }
 
@@ -670,6 +672,14 @@ function setupEventListeners() {
   // Calendar Switcher (Umschalter zwischen Privat- und Arbeits-Kalender)
   const categorySwitcher = document.getElementById('categorySwitcher');
   if (categorySwitcher) {
+    // Show/hide the header switcher based on the personalize toggle
+    const updateCategorySwitcherVisibility = () => {
+      const enabled = localStorage.getItem('categoryFilterEnabled') === 'true';
+      categorySwitcher.style.display = enabled ? '' : 'none';
+    };
+    updateCategorySwitcherVisibility();
+    window.updateCategorySwitcherVisibility = updateCategorySwitcherVisibility;
+
     const switchButtons = categorySwitcher.querySelectorAll('.category-switch-btn');
 
     // Restore the active calendar from the saved state ('' = all)


### PR DESCRIPTION
## Summary

Drei Bugfixes aus dem User-Feedback (direkt gegen `main`):

1. **Kategorie-Filter-Toggle:** Unter Personalisieren gab es nur Beschreibungstext, keinen Schalter. Neuer Toggle `categoryFilterToggle` blendet den Header-Umschalter (Alle/Privat/Beruflich) ein/aus, persistiert in `localStorage.categoryFilterEnabled`.
2. **(BETA) bei Erinnerungen:** Titel zeigt jetzt „ERINNERUNGEN (BETA)" / „REMINDERS (BETA)", analog zu „CLOUD BACKUP (BETA)".
3. **Mülleimer (Done):** War bereits korrekt deployed — kein Code-Fix nötig (war Browser-Cache).

### Konsistenz
Header-Switcher, Render-Filter und Quick-Add-Kategorieauswahl respektieren jetzt alle `categoryFilterEnabled`. Deaktiviert → alles ausgeblendet, gespeicherte Auswahl wird nicht mehr angewendet.

## Test plan

- [ ] Personalisieren → Kategorie-Filter: Toggle vorhanden, schaltet Header-Umschalter sichtbar/unsichtbar
- [ ] Toggle aus → kein Switcher im Header, Quick-Add zeigt keine Kategorieauswahl, kein Filter aktiv
- [ ] Toggle an → Switcher sichtbar, Filterung + Quick-Add-Auswahl funktionieren
- [ ] Erinnerungen-Titel zeigt „(BETA)" in DE und EN
- [ ] Sprachwechsel DE↔EN aktualisiert beide Labels korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)