### PR TITLE
chore: Cache-Cleanup-Workflow (#84)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,10 +1,11 @@
 name: Cache Cleanup
 
-# Läuft wöchentlich oder manuell
+# Löscht alte GitHub-Actions-Caches, damit das 10-GB-Repo-Limit nicht von
+# Build-Caches (node_modules, Gradle, Expo) vollläuft.
+# Läuft wöchentlich (So 03:00 UTC) oder manuell.
 on:
   schedule:
-    # Jeden Sonntag um 03:00 UTC
-    - cron: '0 3 * * 0'
+    - cron: "0 3 * * 0"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fügt den projektübergreifend standardisierten Cache-Cleanup-Workflow hinzu bzw. gleicht ihn an (wöchentlich So 03:00 UTC + `workflow_dispatch`).

Teil von Audit S540d/project-templates#84 (Cache-Cleanup-Workflows in allen Projekten vereinheitlichen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)