### PR TITLE
Release: Quick-Add-Modal-Redesign (PR #346)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,16 @@ Balkendiagramm im Metriken-Dialog, hinter **Smart Features**-Flag:
 - CSS-Klassen in `style.css`: `.matrix-stats-bars`, `.matrix-stats-row`, `.matrix-stats-bar-wrap`, `.matrix-stats-bar`
 - i18n: `metrics.matrixStats` in `translations.js`
 
+### Quick-Add-Modal: kompaktes Layout (PR #346)
+
+Das „Neue Aufgabe"-Fenster (`#quickAddModal` in `index.html`, geöffnet via `openQuickAddModal()` in `js/modules/ui.js`) wurde verschlankt, weil selten genutzte Optionen zu viel Platz beanspruchten:
+
+- **Wiederholung** (`#quickRecurringEnabled`) und **Fälligkeit** (`#quickDueDateEnabled`) sind jetzt Checkbox+Icon-Buttons (`.icon-toggle`, `#quickRecurringToggle` / `#quickDueDateToggle`) im selben cleanen SVG-Stil wie der Fokus-Modus-Toggle (`#focusModeToggle`, Feather-Icons mit `stroke="currentColor"`, Rahmen aus `--card-bg`/`--grid-color`). Aktiv-Zustand: Klasse `icon-toggle-checked`, Akzentfarbe `#667eea` + Glow (Listener in `script.js`, `setupEventListeners()`).
+- Checkbox-Fälligkeit blendet `#quickAddDueDate` ein und ruft `showPicker()` auf, um den nativen Kalender direkt zu öffnen.
+- **Abbrechen**-Button entfernt (Schließen weiterhin per Klick außerhalb des Modals).
+- **Hinzufügen**-Button entfernt; stattdessen ein **OK**-Button (`#quickAddSubmitBtn`, Text aus `lang.buttons.ok`) direkt neben dem Eingabefeld (`.quick-add-input-row`).
+- Neuer i18n-Key `buttons.ok` (de/en) in `translations.js`.
+
 ### Kategorien / Kalender-Umschalter (Issue #198 + #259, PR #260)
 
 Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` oder `'business'` (siehe `filterByCategory` in `js/modules/tasks.js`). Aufgaben ohne Kategorie werden beim Filtern wie `'private'` behandelt.
@@ -129,6 +139,7 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 
 ### Kürzlich erledigt
 
+- **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt
 - **#179** – Export CSV/Markdown, Smart Suggest (Quadrant-Vorschlag), Matrix-Verteilung in Metriken (PR #332, gemerged 2026-06-19)
 - **#257** – `docs/last-backup.txt` mit letztem manuellen Export-Datum erstellt
 - **#264** – Test-Coverage auf 80%+ angehoben; vitest-Schwellenwerte auf 80%; Badge in README
@@ -140,3 +151,4 @@ Epic #95 (Production-Grade Dev Setup) wurde am 2026-05-30 als `completed` geschl
 ## Bekannte Eigenheiten
 
 - Beim Rebase von `main`-basierten Branches auf `testing` gibt es Konflikte in `AndroidManifest.xml` und `colors.xml`, weil `testing` die Farb-Struktur grundlegend überarbeitet hat (alles `#000000`, keine `colorPrimary` mehr).
+- In `style.css` werden an mehreren Stellen (`.focus-mode-toggle.active`, `.category-select-btn.active` u.a.) die CSS-Variablen `--primary-color`, `--primary`, `--primary-rgb` und `--hover-bg` referenziert, die aber nirgends in `:root` definiert sind – diese Deklarationen sind aktuell wirkungslos (No-ops). Der tatsächlich sichtbare Akzentton der App ist der Literal-Hex-Wert `#667eea` (siehe `.btn.active`). Beim nächsten CSS-Aufräumen entweder die Variablen in `:root` definieren oder die toten `var(...)`-Referenzen durch `#667eea` ersetzen.

--- a/index.html
+++ b/index.html
@@ -330,16 +330,48 @@
           <span id="smartSuggestText"></span>
         </div>
 
-        <!-- Compact icon toggles for recurring + due date -->
+        <!-- Compact icon toggles for recurring + due date (same clean SVG-icon style as the focus-mode toggle) -->
         <div class="quick-add-toggles">
           <label class="icon-toggle" id="quickRecurringToggle">
-            <input type="checkbox" id="quickRecurringEnabled" />
-            <span class="icon-toggle-icon" aria-hidden="true">🔁</span>
+            <input type="checkbox" id="quickRecurringEnabled" class="sr-only" />
+            <svg
+              class="icon-toggle-icon"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="17 1 21 5 17 9" />
+              <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+              <polyline points="7 23 3 19 7 15" />
+              <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+            </svg>
             <span id="quickRecurringEnableText" class="sr-only">Make recurring</span>
           </label>
           <label class="icon-toggle" id="quickDueDateToggle">
-            <input type="checkbox" id="quickDueDateEnabled" />
-            <span class="icon-toggle-icon" aria-hidden="true">📅</span>
+            <input type="checkbox" id="quickDueDateEnabled" class="sr-only" />
+            <svg
+              class="icon-toggle-icon"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+              <line x1="16" y1="2" x2="16" y2="6" />
+              <line x1="8" y1="2" x2="8" y2="6" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
             <span id="quickAddDueDateLabel" class="sr-only">Due Date</span>
           </label>
         </div>

--- a/index.html
+++ b/index.html
@@ -308,15 +308,18 @@
         <h3 id="quickAddTitle">New Task</h3>
         <p id="quickAddCategory" class="quick-add-category"></p>
 
-        <div class="quick-add-input-wrapper">
-          <input
-            type="text"
-            id="quickAddInput"
-            placeholder="What do you want to do?"
-            maxlength="140"
-            autocomplete="off"
-          />
-          <span id="quickAddCharCount" class="char-counter">0/140</span>
+        <div class="quick-add-input-row">
+          <div class="quick-add-input-wrapper">
+            <input
+              type="text"
+              id="quickAddInput"
+              placeholder="What do you want to do?"
+              maxlength="140"
+              autocomplete="off"
+            />
+            <span id="quickAddCharCount" class="char-counter">0/140</span>
+          </div>
+          <button id="quickAddSubmitBtn" class="btn quick-add-ok-btn">OK</button>
         </div>
         <div
           id="smartSuggestHint"
@@ -327,82 +330,84 @@
           <span id="smartSuggestText"></span>
         </div>
 
-        <!-- Recurring Task Configuration -->
-        <div class="recurring-config-quick">
-          <label class="recurring-enable">
+        <!-- Compact icon toggles for recurring + due date -->
+        <div class="quick-add-toggles">
+          <label class="icon-toggle" id="quickRecurringToggle">
             <input type="checkbox" id="quickRecurringEnabled" />
-            <span id="quickRecurringEnableText">🔁 Make recurring</span>
+            <span class="icon-toggle-icon" aria-hidden="true">🔁</span>
+            <span id="quickRecurringEnableText" class="sr-only">Make recurring</span>
           </label>
+          <label class="icon-toggle" id="quickDueDateToggle">
+            <input type="checkbox" id="quickDueDateEnabled" />
+            <span class="icon-toggle-icon" aria-hidden="true">📅</span>
+            <span id="quickAddDueDateLabel" class="sr-only">Due Date</span>
+          </label>
+        </div>
 
-          <div id="quickRecurringOptions" class="recurring-options">
-            <div class="recurring-option">
-              <label>
-                <input type="radio" name="quickRecurringType" value="daily" checked />
-                <span id="quickRecurringDaily">Daily</span>
-              </label>
+        <!-- Recurring Task Configuration -->
+        <div id="quickRecurringOptions" class="recurring-options">
+          <div class="recurring-option">
+            <label>
+              <input type="radio" name="quickRecurringType" value="daily" checked />
+              <span id="quickRecurringDaily">Daily</span>
+            </label>
+          </div>
+          <div class="recurring-option">
+            <label>
+              <input type="radio" name="quickRecurringType" value="weekly" />
+              <span id="quickRecurringWeekly">Weekly</span>
+            </label>
+            <div id="quickWeekdaysContainer" class="weekdays-container">
+              <label
+                ><input type="checkbox" class="weekday-check" value="1" />
+                <span id="quickMon">Mon</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="2" />
+                <span id="quickTue">Tue</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="3" />
+                <span id="quickWed">Wed</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="4" />
+                <span id="quickThu">Thu</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="5" />
+                <span id="quickFri">Fri</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="6" />
+                <span id="quickSat">Sat</span></label
+              >
+              <label
+                ><input type="checkbox" class="weekday-check" value="0" />
+                <span id="quickSun">Sun</span></label
+              >
             </div>
-            <div class="recurring-option">
-              <label>
-                <input type="radio" name="quickRecurringType" value="weekly" />
-                <span id="quickRecurringWeekly">Weekly</span>
-              </label>
-              <div id="quickWeekdaysContainer" class="weekdays-container">
-                <label
-                  ><input type="checkbox" class="weekday-check" value="1" />
-                  <span id="quickMon">Mon</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="2" />
-                  <span id="quickTue">Tue</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="3" />
-                  <span id="quickWed">Wed</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="4" />
-                  <span id="quickThu">Thu</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="5" />
-                  <span id="quickFri">Fri</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="6" />
-                  <span id="quickSat">Sat</span></label
-                >
-                <label
-                  ><input type="checkbox" class="weekday-check" value="0" />
-                  <span id="quickSun">Sun</span></label
-                >
-              </div>
-            </div>
-            <div class="recurring-option">
-              <label>
-                <input type="radio" name="quickRecurringType" value="monthly" />
-                <span id="quickRecurringMonthly">Monthly</span>
-              </label>
-              <div id="quickMonthDayContainer">
-                <input
-                  type="number"
-                  id="quickMonthDay"
-                  min="1"
-                  max="31"
-                  value="1"
-                  placeholder="Day (1-31)"
-                />
-              </div>
+          </div>
+          <div class="recurring-option">
+            <label>
+              <input type="radio" name="quickRecurringType" value="monthly" />
+              <span id="quickRecurringMonthly">Monthly</span>
+            </label>
+            <div id="quickMonthDayContainer">
+              <input
+                type="number"
+                id="quickMonthDay"
+                min="1"
+                max="31"
+                value="1"
+                placeholder="Day (1-31)"
+              />
             </div>
           </div>
         </div>
 
-        <!-- Due Date Configuration -->
-        <div class="due-date-config">
-          <label for="quickAddDueDate" class="due-date-label">
-            <span id="quickAddDueDateLabel">Due Date</span>
-          </label>
-          <input type="date" id="quickAddDueDate" class="due-date-input" />
-        </div>
+        <!-- Due Date Configuration (opens when the calendar toggle above is checked) -->
+        <input type="date" id="quickAddDueDate" class="due-date-input" style="display: none" />
 
         <!-- Category Selection (shown only when feature enabled) -->
         <div id="quickAddCategoryConfig" class="category-config" style="display: none">
@@ -432,11 +437,6 @@
               <span id="quickAddCategoryBusiness">Beruflich</span>
             </button>
           </div>
-        </div>
-
-        <div class="modal-buttons">
-          <button id="quickAddSubmitBtn" class="btn submit-btn">Add</button>
-          <button id="quickAddCancelBtn" class="btn cancel-btn">Cancel</button>
         </div>
       </div>
     </div>

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -34,6 +34,7 @@ export const translations = {
       add: 'Hinzufügen',
       cancel: 'Abbrechen',
       close: 'Schließen',
+      ok: 'OK',
     },
     settings: {
       title: 'Einstellungen',
@@ -225,6 +226,7 @@ export const translations = {
       add: 'Add',
       cancel: 'Cancel',
       close: 'Close',
+      ok: 'OK',
     },
     settings: {
       title: 'Settings',
@@ -599,12 +601,7 @@ export function updateLanguageUI(renderAllTasksCallback) {
 
   const quickAddSubmitBtn = document.getElementById('quickAddSubmitBtn');
   if (quickAddSubmitBtn) {
-    quickAddSubmitBtn.textContent = lang.buttons.add;
-  }
-
-  const quickAddCancelBtn = document.getElementById('quickAddCancelBtn');
-  if (quickAddCancelBtn) {
-    quickAddCancelBtn.textContent = lang.buttons.cancel;
+    quickAddSubmitBtn.textContent = lang.buttons.ok;
   }
 
   // Update Quick Add Due Date label
@@ -612,11 +609,19 @@ export function updateLanguageUI(renderAllTasksCallback) {
   if (quickAddDueDateLabel) {
     quickAddDueDateLabel.textContent = lang.quickAddModal.dueDate;
   }
+  const quickDueDateToggle = document.getElementById('quickDueDateToggle');
+  if (quickDueDateToggle) {
+    quickDueDateToggle.title = lang.quickAddModal.dueDate;
+  }
 
   // Update Quick Add Recurring texts
   const quickRecurringEnableText = document.getElementById('quickRecurringEnableText');
   if (quickRecurringEnableText) {
     quickRecurringEnableText.textContent = lang.recurring.enableLabel;
+  }
+  const quickRecurringToggle = document.getElementById('quickRecurringToggle');
+  if (quickRecurringToggle) {
+    quickRecurringToggle.title = lang.recurring.enableLabel;
   }
 
   const quickRecurringDaily = document.getElementById('quickRecurringDaily');

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -1201,9 +1201,9 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   const quickAddCategory = document.getElementById('quickAddCategory');
   const quickAddTitle = document.getElementById('quickAddTitle');
   const quickAddSubmitBtn = document.getElementById('quickAddSubmitBtn');
-  const quickAddCancelBtn = document.getElementById('quickAddCancelBtn');
   const quickRecurringEnabled = document.getElementById('quickRecurringEnabled');
   const quickRecurringOptions = document.getElementById('quickRecurringOptions');
+  const quickDueDateEnabled = document.getElementById('quickDueDateEnabled');
 
   if (!quickAddModal || !quickAddInput) {
     return;
@@ -1213,6 +1213,7 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   quickAddInput.value = '';
   quickRecurringEnabled.checked = false;
   quickRecurringOptions.classList.remove('expanded');
+  document.getElementById('quickRecurringToggle')?.classList.remove('icon-toggle-checked');
   document.getElementById('quickWeekdaysContainer')?.classList.remove('expanded');
   document.getElementById('quickMonthDayContainer')?.classList.remove('expanded');
   document.querySelector('input[name="quickRecurringType"][value="daily"]').checked = true;
@@ -1221,7 +1222,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   const dueDateInput = document.getElementById('quickAddDueDate');
   if (dueDateInput) {
     dueDateInput.value = '';
+    dueDateInput.style.display = 'none';
   }
+  if (quickDueDateEnabled) {
+    quickDueDateEnabled.checked = false;
+  }
+  document.getElementById('quickDueDateToggle')?.classList.remove('icon-toggle-checked');
 
   // Show category selector only when the category filter feature is enabled,
   // and preselect the active calendar (Privat/Beruflich)
@@ -1270,6 +1276,20 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   const quickRecurringEnableText = document.getElementById('quickRecurringEnableText');
   if (quickRecurringEnableText) {
     quickRecurringEnableText.textContent = lang.recurring.enableLabel;
+  }
+  const quickRecurringToggle = document.getElementById('quickRecurringToggle');
+  if (quickRecurringToggle) {
+    quickRecurringToggle.title = lang.recurring.enableLabel;
+  }
+
+  // Update due date label
+  const quickAddDueDateLabel = document.getElementById('quickAddDueDateLabel');
+  if (quickAddDueDateLabel) {
+    quickAddDueDateLabel.textContent = lang.quickAddModal.dueDate;
+  }
+  const quickDueDateToggle = document.getElementById('quickDueDateToggle');
+  if (quickDueDateToggle) {
+    quickDueDateToggle.title = lang.quickAddModal.dueDate;
   }
 
   // Update recurring interval labels
@@ -1352,15 +1372,8 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   // Remove old listeners and add new ones
   const newSubmitBtn = quickAddSubmitBtn.cloneNode(true);
   quickAddSubmitBtn.parentNode.replaceChild(newSubmitBtn, quickAddSubmitBtn);
-  newSubmitBtn.textContent = lang.buttons.add;
+  newSubmitBtn.textContent = lang.buttons.ok;
   newSubmitBtn.addEventListener('click', handleSubmit);
-
-  const newCancelBtn = quickAddCancelBtn.cloneNode(true);
-  quickAddCancelBtn.parentNode.replaceChild(newCancelBtn, quickAddCancelBtn);
-  newCancelBtn.textContent = lang.buttons.cancel;
-  newCancelBtn.addEventListener('click', () => {
-    quickAddModal.style.display = 'none';
-  });
 
   // Handle Enter key
   const handleKeyPress = (e) => {

--- a/script.js
+++ b/script.js
@@ -1102,12 +1102,39 @@ function setupEventListeners() {
   // Quick add recurring toggle (Fix for Issue #76, smooth expand #314)
   const quickRecurringEnabled = document.getElementById('quickRecurringEnabled');
   const quickRecurringOptions = document.getElementById('quickRecurringOptions');
+  const quickRecurringToggle = document.getElementById('quickRecurringToggle');
   if (quickRecurringEnabled && quickRecurringOptions) {
     quickRecurringEnabled.addEventListener('change', () => {
       quickRecurringOptions.classList.toggle('expanded', quickRecurringEnabled.checked);
+      quickRecurringToggle?.classList.toggle('icon-toggle-checked', quickRecurringEnabled.checked);
       if (!quickRecurringEnabled.checked) {
         document.getElementById('quickWeekdaysContainer')?.classList.remove('expanded');
         document.getElementById('quickMonthDayContainer')?.classList.remove('expanded');
+      }
+    });
+  }
+
+  // Quick add due date toggle: reveal the date input and open the native picker
+  const quickDueDateEnabled = document.getElementById('quickDueDateEnabled');
+  const quickAddDueDate = document.getElementById('quickAddDueDate');
+  const quickDueDateToggle = document.getElementById('quickDueDateToggle');
+  if (quickDueDateEnabled && quickAddDueDate) {
+    quickDueDateEnabled.addEventListener('change', () => {
+      const checked = quickDueDateEnabled.checked;
+      quickAddDueDate.style.display = checked ? '' : 'none';
+      quickDueDateToggle?.classList.toggle('icon-toggle-checked', checked);
+      if (checked) {
+        if (typeof quickAddDueDate.showPicker === 'function') {
+          try {
+            quickAddDueDate.showPicker();
+          } catch {
+            quickAddDueDate.focus();
+          }
+        } else {
+          quickAddDueDate.focus();
+        }
+      } else {
+        quickAddDueDate.value = '';
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -1667,40 +1667,42 @@ body.dark-mode .search-highlight {
   max-height: 80px;
 }
 
-/* Compact icon toggles (recurring / due date) in Quick Add modal */
+/* Compact icon toggles (recurring / due date) in Quick Add modal.
+   Same clean bordered-square SVG-icon style as the focus-mode toggle (header). */
 .quick-add-toggles {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   margin-bottom: 10px;
 }
 
 .icon-toggle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
   cursor: pointer;
-  padding: 6px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  background: var(--task-bg);
-  transition:
-    background 0.2s,
-    border-color 0.2s;
+  background: var(--card-bg);
+  border: 2px solid var(--grid-color);
+  border-radius: 8px;
+  padding: 6px 8px;
+  color: var(--text-color);
+  transition: all 0.2s ease;
+}
+
+.icon-toggle:hover {
+  border-color: #667eea;
+}
+
+/* Explicitly set SVG stroke via CSS to fix currentColor inheritance bug on older Android WebView */
+.icon-toggle-icon {
+  stroke: currentColor;
+  transition: stroke 0.2s ease;
 }
 
 .icon-toggle.icon-toggle-checked {
-  background: var(--primary-color);
-  border-color: var(--primary-color);
-}
-
-.icon-toggle-icon {
-  font-size: 1.1rem;
-  line-height: 1;
-}
-
-.icon-toggle input[type='checkbox'] {
-  cursor: pointer;
-  margin: 0;
+  background: #667eea;
+  border-color: #667eea;
+  color: white;
+  box-shadow: 0 0 12px rgba(102, 126, 234, 0.4);
 }
 
 .sr-only {

--- a/style.css
+++ b/style.css
@@ -1588,9 +1588,23 @@ body.dark-mode .search-highlight {
   font-weight: 500;
 }
 
+.quick-add-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
 .quick-add-input-wrapper {
   position: relative;
-  margin-bottom: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.btn.quick-add-ok-btn {
+  flex-shrink: 0;
+  width: auto;
+  padding: 8px 16px;
 }
 
 .quick-add-input-wrapper input {
@@ -1627,33 +1641,78 @@ body.dark-mode .search-highlight {
   color: #ef4444;
 }
 
-.recurring-config-quick {
-  background: var(--task-bg);
-  padding: 8px;
-  border-radius: 4px;
-  margin-bottom: 10px;
-}
-
-.recurring-config-quick .recurring-options {
+#quickRecurringOptions.recurring-options {
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.28s ease-out;
 }
 
-.recurring-config-quick .recurring-options.expanded {
+#quickRecurringOptions.recurring-options.expanded {
+  background: var(--task-bg);
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 10px;
   max-height: 350px;
 }
 
-.recurring-config-quick .weekdays-container,
-.recurring-config-quick #quickMonthDayContainer {
+#quickRecurringOptions .weekdays-container,
+#quickRecurringOptions #quickMonthDayContainer {
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.2s ease-out;
 }
 
-.recurring-config-quick .weekdays-container.expanded,
-.recurring-config-quick #quickMonthDayContainer.expanded {
+#quickRecurringOptions .weekdays-container.expanded,
+#quickRecurringOptions #quickMonthDayContainer.expanded {
   max-height: 80px;
+}
+
+/* Compact icon toggles (recurring / due date) in Quick Add modal */
+.quick-add-toggles {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.icon-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--task-bg);
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.icon-toggle.icon-toggle-checked {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.icon-toggle-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.icon-toggle input[type='checkbox'] {
+  cursor: pointer;
+  margin: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .recurring-enable {
@@ -1738,13 +1797,6 @@ body.dark-mode .search-highlight {
 }
 
 /* Due Date Configuration */
-.due-date-config {
-  background: var(--task-bg);
-  padding: 8px;
-  border-radius: 4px;
-  margin-bottom: 10px;
-}
-
 .due-date-label {
   display: block;
   font-weight: 500;
@@ -1762,6 +1814,8 @@ body.dark-mode .search-highlight {
   color: var(--text-primary);
   font-size: 0.9rem;
   font-family: inherit;
+  margin-bottom: 10px;
+  box-sizing: border-box;
 }
 
 .due-date-input:focus {

--- a/tests/unit/translations.test.js
+++ b/tests/unit/translations.test.js
@@ -273,8 +273,12 @@ describe('updateLanguageUI', () => {
       <h2 id="quickAddTitle">Old Quick Add Title</h2>
       <input id="quickAddInput" placeholder="Old Quick Add Placeholder">
       <button id="quickAddSubmitBtn">Old Submit</button>
-      <button id="quickAddCancelBtn">Old Cancel</button>
-      <span id="quickRecurringEnableText">Old Quick Enable</span>
+      <label id="quickRecurringToggle">
+        <span id="quickRecurringEnableText">Old Quick Enable</span>
+      </label>
+      <label id="quickDueDateToggle">
+        <span id="quickAddDueDateLabel">Old Due Date</span>
+      </label>
       <span id="quickRecurringDaily">Old Quick Daily</span>
       <span id="quickRecurringWeekly">Old Quick Weekly</span>
       <span id="quickRecurringMonthly">Old Quick Monthly</span>
@@ -456,15 +460,24 @@ describe('updateLanguageUI', () => {
       expect(input.placeholder).toBe('What do you want to do?');
     });
 
-    it('should update quick add buttons to German', () => {
+    it('should update quick add submit button to German OK label', () => {
       setLanguage('de');
       updateLanguageUI(mockCallback);
 
       const submitBtn = document.getElementById('quickAddSubmitBtn');
-      const cancelBtn = document.getElementById('quickAddCancelBtn');
 
-      expect(submitBtn.textContent).toBe('Hinzufügen');
-      expect(cancelBtn.textContent).toBe('Abbrechen');
+      expect(submitBtn.textContent).toBe('OK');
+    });
+
+    it('should update quick add due date label and toggle title', () => {
+      setLanguage('de');
+      updateLanguageUI(mockCallback);
+
+      const dueDateLabel = document.getElementById('quickAddDueDateLabel');
+      const dueDateToggle = document.getElementById('quickDueDateToggle');
+
+      expect(dueDateLabel.textContent).toBe('Fällig am');
+      expect(dueDateToggle.title).toBe('Fällig am');
     });
 
     it('should update quick recurring labels to English', () => {


### PR DESCRIPTION
## Summary
- Release testing → main
- Enthält Quick-Add-Icons-Redesign (kompaktes Modal, Icon-Toggles statt Checkbox+Text, OK statt Hinzufügen/Abbrechen) aus PR #346

## Test plan
- CI/Review-Gate auf diesem PR grün