### PR TITLE
fix: Large-Screen-Kompatibilität — resizeableActivity=true (Play Store #82)

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="${appName}"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:resizeableActivity="true"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Translucent.NoTitleBar"
         tools:ignore="GoogleAppIndexingWarning">


### PR DESCRIPTION
## Summary
- `android:resizeableActivity="true"` an `<application>` in `AndroidManifest.xml` ergänzt
- Behebt Play-Store-Warnung 3 (Größenänderungs-/Ausrichtungsbeschränkungen, Android 16)
- Kein hartes portrait-Lock vorhanden, daher kein weiterer Anpassungsbedarf

Closes #349

## Test plan
- [ ] Build lokal/CI erfolgreich
- [ ] AAB an Play Store hochladen, Warnung 3 prüft sich selbst beim nächsten Review