### PR TITLE
docs: Play-Store-Listing nach docs/ verschieben

### DIFF
--- a/Android/PLAYSTORE_CHECKLIST.md
+++ b/Android/PLAYSTORE_CHECKLIST.md
@@ -190,84 +190,18 @@ cp icons/icon-512x512.png Android/play-store-assets/icon-512x512.png
 
 ### 🔲 Store Listing Text
 
-#### App Name (50 Zeichen max)
-```
-Eisenhauer Matrix
-```
+Alle Texte (App Name, Short/Full Description) sowie Kategorie & Tags, Content Rating, Privacy Policy, Data Safety und Contact & Support sind zentral gepflegt in:
 
-#### Short Description (80 Zeichen)
-```
-Task-Management nach der Eisenhauer-Matrix-Methode
-```
+**→ [docs/PLAYSTORE_LISTING.md](../docs/PLAYSTORE_LISTING.md)**
 
-#### Full Description (4000 Zeichen)
-```
-Eisenhauer Matrix ist eine moderne Task-Management-App basierend auf der
-Eisenhauer-Matrix-Methode zur Priorisierung von Aufgaben.
-
-🎯 FEATURES:
-• 5 Segmente: Do, Schedule, Delegate, Ignore, Done
-• Wiederkehrende Aufgaben (täglich, wöchentlich, monatlich)
-• Drag & Drop zwischen Segmenten (Maus, Touch, Keyboard)
-• Cloud-Synchronisation mit Firebase
-• Offline-First Architecture mit automatischer Sync
-• Benutzer-Accounts (Google/Apple Sign-In) oder Gastmodus
-• Export/Import (JSON Backups)
-• Dark Mode (automatisch basierend auf System)
-• Vollständige Tastatursteuerung (Accessibility)
-• Screen Reader Support (VoiceOver, TalkBack)
-
-📱 OFFLINE-FUNKTIONALITÄT:
-Die App funktioniert vollständig offline. Alle Änderungen werden lokal
-gespeichert und automatisch synchronisiert, sobald eine Verbindung besteht.
-Keine Datenverluste!
-
-♿ BARRIEREFREIHEIT:
-WCAG 2.1 Level AA konform mit vollständiger Tastatursteuerung und
-Screen Reader Support.
-
-🔒 DATENSCHUTZ:
-Ihre Daten werden sicher in Firebase Cloud Firestore gespeichert (bei Anmeldung)
-oder lokal auf Ihrem Gerät (Gastmodus mit IndexedDB). Keine Tracking,
-keine Werbung, keine Weitergabe an Dritte.
-
-🌐 CROSS-PLATFORM:
-Als Progressive Web App (PWA) auch im Browser nutzbar unter:
-https://s540d.github.io/Eisenhauer/
-
-📖 OPEN SOURCE:
-Der komplette Quellcode ist auf GitHub verfügbar:
-https://github.com/S540d/Eisenhauer
-
----
-
-Made with ❤️ by S540d
-```
-
-### 🔲 Kategorie & Tags
-- [ ] Kategorie: **Productivity**
-- [ ] Tags: task management, productivity, eisenhower matrix, todo, gtd
-
-### 🔲 Content Rating
-- [ ] Questionnaire ausgefüllt
-- [ ] Rating: **Everyone (3+)**
-
-### 🔲 Privacy Policy
-- [ ] URL: `https://s540d.github.io/Eisenhauer/privacy-policy.html`
-- [ ] Policy aktuell und vollständig
-- [ ] In Play Console verlinkt
-
-### 🔲 Data Safety Section
-- [ ] Datenerfassung: Ja (Email für Login, Tasks)
-- [ ] Datentypen: Personal Info (Email), App Activity (Tasks)
-- [ ] Weitergabe: Nein
-- [ ] Verschlüsselung: Ja (HTTPS, Firebase)
-- [ ] Datenlöschung: Ja (Account-Löschung in App möglich)
-- [ ] Keine Ads, kein Tracking
-
-### 🔲 Contact & Support
-- [ ] Developer Email: [Deine Email]
-- [ ] Support URL (optional): `https://github.com/S540d/Eisenhauer/issues`
+- [ ] App Name übernommen
+- [ ] Short Description übernommen
+- [ ] Full Description übernommen
+- [ ] Kategorie & Tags übernommen
+- [ ] Content Rating Questionnaire ausgefüllt
+- [ ] Privacy-Policy-URL in Play Console verlinkt
+- [ ] Data Safety Form ausgefüllt
+- [ ] Contact & Support hinterlegt
 
 ---
 
@@ -286,21 +220,7 @@ Made with ❤️ by S540d
 - [ ] Bugs behoben
 
 ### 🔲 Release Notes
-```
-🎉 Erste Veröffentlichung der Eisenhauer Matrix App!
-
-✨ Features:
-• Task-Management nach Eisenhauer-Matrix-Methode
-• Wiederkehrende Aufgaben (täglich, wöchentlich, monatlich)
-• Cloud-Sync und Offline-Support
-• Dark Mode
-• Export/Import für Backups
-• Vollständig barrierefrei (WCAG 2.1 AA)
-
-🙏 Wir freuen uns über Feedback und Bewertungen!
-
-📧 Support: https://github.com/S540d/Eisenhauer/issues
-```
+Vorlage siehe [docs/PLAYSTORE_LISTING.md](../docs/PLAYSTORE_LISTING.md#release-notes-vorlage-für-versions-updates).
 
 ### 🔲 Rollout Strategie
 - [ ] **Option 1:** 100% Direct Launch (empfohlen für erste Version)

--- a/docs/PLAYSTORE_LISTING.md
+++ b/docs/PLAYSTORE_LISTING.md
@@ -1,0 +1,123 @@
+# Play Store Listing: Eisenhauer Matrix
+
+Zentrale, pflegbare Quelle für alle Texte und Metadaten des Google-Play-Store-Eintrags. Wird beim Aktualisieren des Store-Eintrags 1:1 in die Play Console übernommen.
+
+Der technische Ablauf (Signing, Build, Upload, Rollout) bleibt in [`Android/PLAYSTORE_CHECKLIST.md`](../Android/PLAYSTORE_CHECKLIST.md); dieses Dokument enthält nur den Listing-**Inhalt**.
+
+---
+
+## App Name (50 Zeichen max.)
+
+```
+Eisenhauer Matrix
+```
+
+## Short Description (80 Zeichen max.)
+
+```
+Task-Management nach der Eisenhauer-Matrix-Methode
+```
+
+## Full Description (4000 Zeichen max.)
+
+```
+Eisenhauer Matrix ist eine moderne Task-Management-App basierend auf der
+Eisenhauer-Matrix-Methode zur Priorisierung von Aufgaben.
+
+🎯 FEATURES:
+• 5 Segmente: Do, Schedule, Delegate, Ignore, Done
+• Wiederkehrende Aufgaben (täglich, wöchentlich, monatlich)
+• Drag & Drop zwischen Segmenten (Maus, Touch, Keyboard)
+• Cloud-Synchronisation mit Firebase
+• Offline-First Architecture mit automatischer Sync
+• Benutzer-Accounts (Google/Apple Sign-In) oder Gastmodus
+• Export/Import (JSON Backups)
+• Dark Mode (automatisch basierend auf System)
+• Vollständige Tastatursteuerung (Accessibility)
+• Screen Reader Support (VoiceOver, TalkBack)
+
+📱 OFFLINE-FUNKTIONALITÄT:
+Die App funktioniert vollständig offline. Alle Änderungen werden lokal
+gespeichert und automatisch synchronisiert, sobald eine Verbindung besteht.
+Keine Datenverluste!
+
+♿ BARRIEREFREIHEIT:
+WCAG 2.1 Level AA konform mit vollständiger Tastatursteuerung und
+Screen Reader Support.
+
+🔒 DATENSCHUTZ:
+Ihre Daten werden sicher in Firebase Cloud Firestore gespeichert (bei Anmeldung)
+oder lokal auf Ihrem Gerät (Gastmodus mit IndexedDB). Keine Tracking,
+keine Werbung, keine Weitergabe an Dritte.
+
+🌐 CROSS-PLATFORM:
+Als Progressive Web App (PWA) auch im Browser nutzbar unter:
+https://s540d.github.io/Eisenhauer/
+
+📖 OPEN SOURCE:
+Der komplette Quellcode ist auf GitHub verfügbar:
+https://github.com/S540d/Eisenhauer
+
+---
+
+Made with ❤️ by S540d
+```
+
+> **Hinweis (Issue #352):** Diese Texte sind aktuell eine reine Feature-Aufzählung. Im Rahmen der Wachstums-/Aufwertungsstrategie sollen Short & Full Description überarbeitet werden, sodass die Positionierung (Priorisieren + Reflektieren statt „noch eine Todo-App") in den ersten Zeilen führt, bevor die Feature-Liste folgt.
+
+## Kategorie & Tags
+
+- **Kategorie:** Productivity
+- **Tags:** task management, productivity, eisenhower matrix, todo, gtd
+
+## Content Rating
+
+- **Rating:** Everyone (3+)
+- Questionnaire in der Play Console ausfüllen
+
+## Privacy Policy
+
+- **URL:** `https://s540d.github.io/Eisenhauer/privacy-policy.html`
+- In Play Console unter Store-Präsenz verlinken
+
+## Data Safety Section
+
+- **Datenerfassung:** Ja (Email für Login, Tasks)
+- **Datentypen:** Personal Info (Email), App Activity (Tasks)
+- **Weitergabe an Dritte:** Nein
+- **Verschlüsselung:** Ja (HTTPS, Firebase)
+- **Datenlöschung:** Ja (Account-Löschung in App möglich)
+- **Ads / Tracking:** Keine
+
+## Contact & Support
+
+- **Developer Email:** [Deine Email]
+- **Support URL (optional):** `https://github.com/S540d/Eisenhauer/issues`
+
+## Release Notes (Vorlage für Versions-Updates)
+
+```
+🎉 Erste Veröffentlichung der Eisenhauer Matrix App!
+
+✨ Features:
+• Task-Management nach Eisenhauer-Matrix-Methode
+• Wiederkehrende Aufgaben (täglich, wöchentlich, monatlich)
+• Cloud-Sync und Offline-Support
+• Dark Mode
+• Export/Import für Backups
+• Vollständig barrierefrei (WCAG 2.1 AA)
+
+🙏 Wir freuen uns über Feedback und Bewertungen!
+
+📧 Support: https://github.com/S540d/Eisenhauer/issues
+```
+
+## Screenshots & Grafiken
+
+Assets liegen in [`Android/playstore-assets/`](../Android/playstore-assets/) (Feature Graphic 1024×500px, App-Icon 512×512px, Screenshots 1080×1920px Portrait). Erstellungsprozess siehe [`Android/playstore-assets/README.md`](../Android/playstore-assets/README.md).
+
+**Benötigte Screenshots (min. 2, max. 8):**
+1. Hauptansicht mit allen Segmenten (Pflicht)
+2. Dark Mode (empfohlen)
+3. Task erstellen / Wiederkehrende Aufgaben
+4. Drag & Drop Demonstration

--- a/docs/README_ANDROID.md
+++ b/docs/README_ANDROID.md
@@ -94,6 +94,7 @@ Android/app/build/outputs/bundle/release/app-release.aab
 
 - **Setup Guide:** [Android/README.md](Android/README.md) (10k+ words)
 - **Play Store Checklist:** [Android/PLAYSTORE_CHECKLIST.md](Android/PLAYSTORE_CHECKLIST.md)
+- **Play Store Listing (Texts & Metadata):** [PLAYSTORE_LISTING.md](PLAYSTORE_LISTING.md)
 - **Keystore Info:** `Android/KEYSTORE_INFO.md` (local only, not in Git)
 - **Complete Status:** [ANDROID_STATUS.md](ANDROID_STATUS.md)
 


### PR DESCRIPTION
## Beschreibung

Konsolidiert den Play-Store-Listing-Inhalt an einem zentralen Ort, wie in Issue #352 vorgeschlagen.

- Neu: **`docs/PLAYSTORE_LISTING.md`** – App Name, Short/Full Description, Kategorie & Tags, Content Rating, Privacy-Policy-Link, Data-Safety-Angaben, Contact & Support, Release-Notes-Vorlage sowie Verweis auf die Screenshot-Assets.
- `Android/PLAYSTORE_CHECKLIST.md`: Der bisher dort duplizierte Listing-Text wurde entfernt und durch Verweise auf `docs/PLAYSTORE_LISTING.md` ersetzt (Checkliste bleibt reine Prozess-/Ablaufliste für Signing, Build, Upload, Rollout).
- `docs/README_ANDROID.md`: Neuer Eintrag in der Dokumentationsliste, der auf `docs/PLAYSTORE_LISTING.md` verweist.

Kein Code betroffen – reine Dokumentations-Konsolidierung, keine funktionalen Änderungen.

## Art der Änderung

- [x] Dokumentation Update

## Cross-Platform Kompatibilität

Betrifft diesen PR plattformspezifischen Code? **Nein** – nur Markdown-Dokumentation, kein App-Code geändert.

## Testing Checklist

- [x] Keine Code-Änderungen, daher kein Build/Test-Lauf nötig
- [x] Interne Links geprüft (`docs/PLAYSTORE_LISTING.md` ↔ `Android/PLAYSTORE_CHECKLIST.md` ↔ `docs/README_ANDROID.md`)

## Zusätzliche Notizen

Folgeissue #352 enthält den vollständigen Wachstums-/Aufwertungsplan (funktional, optisch, Store-Listing); dieser PR setzt nur den organisatorischen Teil („Listing zentral unter `docs/` pflegbar machen") um.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124MeWgJHh4uTgiWwErQ64t)_