### PR TITLE
Design-Tokens, Onboarding & Micro-Interactions (Issue #352 B1-B3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,14 @@ Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` od
 - **#259/#260:** Sichtbarer, segmentierter **Umschalter** im Header (`#categorySwitcher`, Buttons `Alle / Privat / Beruflich`). Persistiert in `localStorage` unter `categoryFilter` (`''` = Alle). Filtert beim Render und der Quick-Add-Dialog wählt die aktive Kategorie vor (pro Aufgabe überschreibbar, inkl. „Keine"). Es gibt **keinen** separaten Auto-Assign-Schalter mehr – die sichtbare Quick-Add-Vorauswahl ist die einzige Quelle der Wahrheit (alle Adds laufen über das Modal).
 - i18n: `categoryFilter.{switcherLabel,all,private,business,...}` in `js/modules/translations.js`; `updateLanguageUI` aktualisiert Button-Texte **und** das barrierefreie `aria-label` des Switchers.
 
+### Design-Tokens, Onboarding & Micro-Interactions (Issue #352 B1–B3)
+
+**B1 – Design-Tokens konsolidieren:** Die zuvor toten CSS-Variablen `--primary-color`, `--primary`, `--primary-rgb` und `--hover-bg` sind jetzt in `:root` (und im `prefers-color-scheme: dark`-Block für `--hover-bg`) echt definiert (`#667eea` / `102, 126, 234`). Alle Literal-Hex-Vorkommen von `#667eea` in `style.css` (außer der Segment-Farbmap in `script.js`, die eine andere Bedeutung hat) wurden durch `var(--primary-color)` ersetzt.
+
+**B2 – Onboarding & Empty States:** Neues Modul `js/modules/onboarding.js`. Solange eine Aufgaben-Matrix komplett leer ist (kein Task je hinzugefügt) und Onboarding nicht dismissed wurde, zeigt `renderSegment()` in `js/modules/ui.js` pro leerem Segment 1–4 einen dismissable Demo-Task samt kurzer Quadranten-Erklärung (`translations.js` → `onboarding.{demoTasks,explanations,demoBadge,dismissLabel}`). Nach dem ersten echten `handleAddTask()`-Aufruf (script.js) wird Onboarding dauerhaft über `dismissOnboarding()` beendet (localStorage `onboardingDismissed`), damit es nicht wiederkehrt, wenn die Matrix später erneut leer wird. Einzelne Demo-Tasks lassen sich per ✕ ausblenden (`dismissSegmentDemo()`, localStorage `onboardingDemoDismissed`); sind alle vier dismissed, gilt Onboarding ebenfalls als beendet. Danach (und für Segment 5 „Fertig!") zeigt jedes leere Segment eine freundliche Empty-State-Message (`translations.js` → `emptyState.{1-5}`).
+
+**B3 – Micro-Interactions & Motion:** „Erledigt"-Häkchen lösen eine kurze Puls-/Glow-Animation aus (`createTaskElement()` in `ui.js` fügt `task-completing` hinzu, `callbacks.onToggle` wird erst nach ~220ms aufgerufen; bei `prefers-reduced-motion: reduce` sofort ohne Delay). Drag & Drop dimmt jetzt alle Nicht-Ziel-Quadranten (`body.is-dragging .segment:not(.drag-target-segment)`) sowohl im Touch-Pfad (`DragManager#activateDragMode`/`#detectDropTarget`) als auch im Desktop-HTML5-DnD-Pfad (`#handleDragStart`/`#handleDragEnd`/`setupDropZone()` in `drag-manager.js`). Alle neuen Animationen sind im bestehenden `@media (prefers-reduced-motion: reduce)`-Block am Ende von `style.css` deaktiviert.
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):
@@ -139,6 +147,7 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 
 ### Kürzlich erledigt
 
+- **#352 B1–B3** – Design-Tokens konsolidiert (`--primary-color`/`--primary`/`--primary-rgb`/`--hover-bg` echt definiert), Onboarding mit dismissable Demo-Tasks + Quadranten-Erklärung + freundlichen Empty States (`js/modules/onboarding.js`), „Erledigt"-Micro-Interaction + klareres Drag-Feedback (Segment-Dimming), siehe Abschnitt „Design-Tokens, Onboarding & Micro-Interactions" oben
 - **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt
 - **#179** – Export CSV/Markdown, Smart Suggest (Quadrant-Vorschlag), Matrix-Verteilung in Metriken (PR #332, gemerged 2026-06-19)
 - **#257** – `docs/last-backup.txt` mit letztem manuellen Export-Datum erstellt
@@ -151,4 +160,3 @@ Epic #95 (Production-Grade Dev Setup) wurde am 2026-05-30 als `completed` geschl
 ## Bekannte Eigenheiten
 
 - Beim Rebase von `main`-basierten Branches auf `testing` gibt es Konflikte in `AndroidManifest.xml` und `colors.xml`, weil `testing` die Farb-Struktur grundlegend überarbeitet hat (alles `#000000`, keine `colorPrimary` mehr).
-- In `style.css` werden an mehreren Stellen (`.focus-mode-toggle.active`, `.category-select-btn.active` u.a.) die CSS-Variablen `--primary-color`, `--primary`, `--primary-rgb` und `--hover-bg` referenziert, die aber nirgends in `:root` definiert sind – diese Deklarationen sind aktuell wirkungslos (No-ops). Der tatsächlich sichtbare Akzentton der App ist der Literal-Hex-Wert `#667eea` (siehe `.btn.active`). Beim nächsten CSS-Aufräumen entweder die Variablen in `:root` definieren oder die toten `var(...)`-Referenzen durch `#667eea` ersetzen.

--- a/js/modules/drag-manager.js
+++ b/js/modules/drag-manager.js
@@ -327,6 +327,9 @@ export class DragManager {
     // Visual feedback
     this.element.style.opacity = '0.5';
 
+    // Dim non-target segments for clearer drop feedback (Issue #352 B3)
+    document.body.classList.add('is-dragging');
+
     // Update store
     store.setState(
       {
@@ -363,6 +366,10 @@ export class DragManager {
   #handleDragEnd(_e) {
     // Reset visual state
     this.element.style.opacity = this.state.originalOpacity;
+    document.body.classList.remove('is-dragging');
+    document
+      .querySelectorAll('.segment.drag-target-segment')
+      .forEach((el) => el.classList.remove('drag-target-segment'));
 
     // Update store
     store.setState(
@@ -397,6 +404,9 @@ export class DragManager {
 
     // Prevent pull-to-refresh
     document.body.style.overflow = 'hidden';
+
+    // Dim non-target segments for clearer drop feedback (Issue #352 B3)
+    document.body.classList.add('is-dragging');
 
     // Update store
     store.setState(
@@ -502,11 +512,13 @@ export class DragManager {
       // Remove highlight from old target
       if (this.state.dropTarget) {
         this.state.dropTarget.classList.remove('drag-over');
+        this.state.dropTarget.closest('.segment')?.classList.remove('drag-target-segment');
       }
 
       // Add highlight to new target
       if (dropZone) {
         dropZone.classList.add('drag-over');
+        dropZone.closest('.segment')?.classList.add('drag-target-segment');
       }
 
       this.state.dropTarget = dropZone;
@@ -535,10 +547,12 @@ export class DragManager {
 
     // Re-enable scrolling
     document.body.style.overflow = '';
+    document.body.classList.remove('is-dragging');
 
     // Remove drop zone highlighting
     if (this.state.dropTarget) {
       this.state.dropTarget.classList.remove('drag-over');
+      this.state.dropTarget.closest('.segment')?.classList.remove('drag-target-segment');
     }
 
     // Haptic feedback on drop
@@ -637,9 +651,11 @@ export class DragManager {
 
     this.element.style.opacity = this.state.originalOpacity;
     document.body.style.overflow = '';
+    document.body.classList.remove('is-dragging');
 
     if (this.state.dropTarget) {
       this.state.dropTarget.classList.remove('drag-over');
+      this.state.dropTarget.closest('.segment')?.classList.remove('drag-target-segment');
     }
 
     store.setState(
@@ -744,15 +760,18 @@ export function setupDropZone(dropZone, onDrop) {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     dropZone.classList.add('drag-over');
+    dropZone.closest('.segment')?.classList.add('drag-target-segment');
   });
 
   dropZone.addEventListener('dragleave', () => {
     dropZone.classList.remove('drag-over');
+    dropZone.closest('.segment')?.classList.remove('drag-target-segment');
   });
 
   dropZone.addEventListener('drop', (e) => {
     e.preventDefault();
     dropZone.classList.remove('drag-over');
+    dropZone.closest('.segment')?.classList.remove('drag-target-segment');
 
     try {
       const data = JSON.parse(e.dataTransfer.getData('application/json'));

--- a/js/modules/onboarding.js
+++ b/js/modules/onboarding.js
@@ -1,0 +1,70 @@
+/**
+ * Onboarding Module (Issue #352 B2)
+ * Empty-matrix quadrant explanations + dismissible demo tasks for new users
+ */
+
+const ONBOARDING_DISMISSED_KEY = 'onboardingDismissed';
+const ONBOARDING_DEMO_DISMISSED_KEY = 'onboardingDemoDismissed';
+const DEMO_SEGMENTS = [1, 2, 3, 4];
+
+/**
+ * Whether onboarding (quadrant explanation + demo tasks) has been fully dismissed
+ * @returns {boolean}
+ */
+export function isOnboardingDismissed() {
+  return localStorage.getItem(ONBOARDING_DISMISSED_KEY) === 'true';
+}
+
+/**
+ * Permanently dismiss onboarding, e.g. once the user has added a real task
+ */
+export function dismissOnboarding() {
+  localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true');
+}
+
+function readDismissedDemoSegments() {
+  try {
+    const raw = localStorage.getItem(ONBOARDING_DEMO_DISMISSED_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Whether the demo task for a specific segment has been dismissed by the user
+ * @param {number} segmentId
+ * @returns {boolean}
+ */
+export function isSegmentDemoDismissed(segmentId) {
+  return readDismissedDemoSegments().includes(segmentId);
+}
+
+/**
+ * Dismiss the demo task for a single segment. Once all demo segments are
+ * dismissed, onboarding is considered fully dismissed.
+ * @param {number} segmentId
+ */
+export function dismissSegmentDemo(segmentId) {
+  const dismissed = new Set(readDismissedDemoSegments());
+  dismissed.add(segmentId);
+  localStorage.setItem(ONBOARDING_DEMO_DISMISSED_KEY, JSON.stringify([...dismissed]));
+
+  if (DEMO_SEGMENTS.every((id) => dismissed.has(id))) {
+    dismissOnboarding();
+  }
+}
+
+/**
+ * Whether the demo task + explanation should be shown for a given empty segment
+ * @param {number} segmentId
+ * @returns {boolean}
+ */
+export function shouldShowSegmentDemo(segmentId) {
+  return (
+    DEMO_SEGMENTS.includes(segmentId) &&
+    !isOnboardingDismissed() &&
+    !isSegmentDemoDismissed(segmentId)
+  );
+}

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -174,6 +174,29 @@ export const translations = {
       4: { title: 'Später!', subtitle: 'optional' },
       5: { title: 'Fertig!', subtitle: '' },
     },
+    onboarding: {
+      demoBadge: 'Beispiel',
+      dismissLabel: 'Beispiel entfernen',
+      explanations: {
+        1: 'Wichtig und dringend – das packst du direkt an.',
+        2: 'Wichtig, aber nicht dringend – dafür planst du dir bewusst Zeit ein.',
+        3: 'Dringend, aber nicht wichtig – das kannst du oft abgeben.',
+        4: 'Weder wichtig noch dringend – das darf warten oder ganz entfallen.',
+      },
+      demoTasks: {
+        1: 'Beispiel: Rechnung heute bezahlen',
+        2: 'Beispiel: Nächste Woche Sport einplanen',
+        3: 'Beispiel: Meeting-Termin abstimmen lassen',
+        4: 'Beispiel: Irgendwann Schreibtisch aufräumen',
+      },
+    },
+    emptyState: {
+      1: 'Hier ist gerade nichts Dringendes – gut so!',
+      2: 'Noch nichts geplant. Was ist dir wichtig?',
+      3: 'Nichts zum Abgeben da.',
+      4: 'Leer – auch das darf mal so bleiben.',
+      5: 'Noch keine Aufgabe erledigt.',
+    },
     recurring: {
       title: 'Wiederkehrende Aufgabe',
       enableLabel: 'Als wiederkehrende Aufgabe',
@@ -365,6 +388,29 @@ export const translations = {
       3: { title: 'Delegate!', subtitle: '' },
       4: { title: 'Ignore!', subtitle: '' },
       5: { title: 'Done!', subtitle: '' },
+    },
+    onboarding: {
+      demoBadge: 'Example',
+      dismissLabel: 'Remove example',
+      explanations: {
+        1: 'Important and urgent — tackle this right away.',
+        2: 'Important, but not urgent — schedule dedicated time for it.',
+        3: 'Urgent, but not important — this is often best delegated.',
+        4: 'Neither important nor urgent — let it wait, or drop it.',
+      },
+      demoTasks: {
+        1: 'Example: Pay an overdue bill today',
+        2: "Example: Plan next week's workout",
+        3: 'Example: Have someone else schedule the meeting',
+        4: 'Example: Tidy the desk someday',
+      },
+    },
+    emptyState: {
+      1: 'Nothing urgent right now — nice!',
+      2: 'Nothing planned yet. What matters to you?',
+      3: 'Nothing to delegate right now.',
+      4: "Empty — and that's fine too.",
+      5: 'No tasks completed yet.',
     },
     recurring: {
       title: 'Recurring Task',

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -9,6 +9,7 @@ import { getRecurringDescription } from './tasks.js';
 import { DragManager } from './drag-manager.js';
 import { announceDragStart, announceDragEnd } from './accessibility.js';
 import { translations } from './translations.js';
+import { shouldShowSegmentDemo } from './onboarding.js';
 
 /**
  * Create a task DOM element
@@ -46,10 +47,21 @@ export function createTaskElement(task, translations, currentLanguage, callbacks
   checkbox.className = 'task-checkbox';
   checkbox.checked = task.checked;
 
-  // Checkbox event listener
+  // Checkbox event listener. When a task is being marked done (not restored),
+  // play a brief "completing" animation before handing off to the callback,
+  // which re-renders the matrix and moves the task into "Done!" (Issue #352 B3).
   if (callbacks.onToggle) {
     checkbox.addEventListener('change', () => {
-      callbacks.onToggle(task.id, task.segment);
+      const justCompleted = checkbox.checked && !task.checked;
+      if (!justCompleted) {
+        callbacks.onToggle(task.id, task.segment);
+        return;
+      }
+
+      const prefersReducedMotion =
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+      div.classList.add('task-completing');
+      setTimeout(() => callbacks.onToggle(task.id, task.segment), prefersReducedMotion ? 0 : 220);
     });
   }
 
@@ -254,6 +266,60 @@ export function createTaskElement(task, translations, currentLanguage, callbacks
 }
 
 /**
+ * Build the placeholder shown in an empty segment: either a dismissible demo
+ * task with a short quadrant explanation (new users, Issue #352 B2) or a
+ * friendly empty-state message once onboarding has been dismissed.
+ * @param {number} segmentId - Segment ID (1-5)
+ * @param {object} translations - Translations object
+ * @param {string} currentLanguage - Current language
+ * @param {object} callbacks - Event callbacks
+ * @returns {HTMLElement}
+ */
+function createEmptyStateElement(segmentId, translations, currentLanguage, callbacks = {}) {
+  const t = translations[currentLanguage] || translations.en;
+  const wrapper = document.createElement('div');
+
+  if (shouldShowSegmentDemo(segmentId)) {
+    wrapper.className = 'segment-empty-state segment-demo-task';
+
+    const badge = document.createElement('span');
+    badge.className = 'segment-demo-badge';
+    badge.textContent = t.onboarding.demoBadge;
+    wrapper.appendChild(badge);
+
+    const demoText = document.createElement('p');
+    demoText.className = 'segment-demo-text';
+    demoText.textContent = t.onboarding.demoTasks[segmentId];
+    wrapper.appendChild(demoText);
+
+    const explanation = document.createElement('p');
+    explanation.className = 'segment-empty-explanation';
+    explanation.textContent = t.onboarding.explanations[segmentId];
+    wrapper.appendChild(explanation);
+
+    const dismissBtn = document.createElement('button');
+    dismissBtn.type = 'button';
+    dismissBtn.className = 'segment-demo-dismiss';
+    dismissBtn.setAttribute('aria-label', t.onboarding.dismissLabel);
+    dismissBtn.title = t.onboarding.dismissLabel;
+    dismissBtn.textContent = '✕';
+    dismissBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (callbacks.onDismissDemo) callbacks.onDismissDemo(segmentId);
+    });
+    wrapper.appendChild(dismissBtn);
+  } else {
+    wrapper.className = 'segment-empty-state';
+    const message = document.createElement('p');
+    message.className = 'segment-empty-message';
+    message.textContent = t.emptyState[segmentId];
+    wrapper.appendChild(message);
+  }
+
+  return wrapper;
+}
+
+/**
  * Render tasks in a specific segment
  * @param {number} segmentId - Segment ID (1-5)
  * @param {object} tasks - Tasks object
@@ -268,6 +334,13 @@ export function renderSegment(segmentId, tasks, translations, currentLanguage, c
   segmentElement.innerHTML = '';
 
   const segmentTasks = tasks[segmentId] || [];
+
+  if (segmentTasks.length === 0) {
+    segmentElement.appendChild(
+      createEmptyStateElement(segmentId, translations, currentLanguage, callbacks)
+    );
+    return;
+  }
 
   // Phase 1: build elements, skipping any task that fails to render. A single
   // corrupt task (e.g. an invalid dueDate or a malformed recurring object) must

--- a/script.js
+++ b/script.js
@@ -105,6 +105,7 @@ import {
   markAutoBackupCompleted,
   trackBackupFailure,
 } from './js/modules/backup.js';
+import { dismissOnboarding, dismissSegmentDemo } from './js/modules/onboarding.js';
 // Old drag-drop.js is now deprecated - using DragManager instead
 // import {
 // setupDragAndDrop,
@@ -192,6 +193,10 @@ async function loadAllTasks() {
 function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null, category = null) {
   if (!taskText || taskText.trim() === '') return;
 
+  // First real task ends onboarding for good, so demo tasks/explanations
+  // don't reappear later just because the matrix becomes empty again.
+  dismissOnboarding();
+
   // The Quick Add modal already encodes the category choice (it preselects the
   // active calendar and lets the user override it, including "Keine"), so the
   // explicitly passed category is used as-is and never silently overridden.
@@ -206,6 +211,14 @@ function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null
     saveGuestTasks(tasks);
   }
 
+  renderTasksWithCallbacks();
+}
+
+/**
+ * Dismiss the onboarding demo task for a single segment (Issue #352 B2)
+ */
+function handleDismissDemo(segmentId) {
+  dismissSegmentDemo(segmentId);
   renderTasksWithCallbacks();
 }
 
@@ -469,6 +482,7 @@ function renderTasksWithCallbacks() {
     onSwipeDelete: handleDeleteTask,
     onEditRecurring: handleEditRecurring,
     onReorder: handleReorderTask,
+    onDismissDemo: handleDismissDemo,
   };
 
   try {

--- a/style.css
+++ b/style.css
@@ -15,6 +15,12 @@
   --grid-color: #e5e7eb;
   --task-bg: #fafafa;
   --input-border: #e0e0e0;
+
+  /* Accent / brand token (Issue #352 B1) */
+  --primary-color: #667eea;
+  --primary: var(--primary-color);
+  --primary-rgb: 102, 126, 234;
+  --hover-bg: rgba(102, 126, 234, 0.1);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -29,6 +35,7 @@
     --grid-color: #404040;
     --task-bg: #1f1f1f;
     --input-border: #4b5563;
+    --hover-bg: rgba(102, 126, 234, 0.2);
   }
 }
 
@@ -358,7 +365,7 @@ header h1,
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--primary-color) 0%, #764ba2 100%);
 }
 
 .login-container {
@@ -1538,7 +1545,7 @@ body.dark-mode .search-highlight {
   margin-top: 6px;
   padding: 5px 10px;
   background: rgba(102, 126, 234, 0.1);
-  border-left: 3px solid #667eea;
+  border-left: 3px solid var(--primary-color);
   border-radius: 0 4px 4px 0;
   font-size: 0.8rem;
   color: var(--text-secondary);
@@ -1689,7 +1696,7 @@ body.dark-mode .search-highlight {
 }
 
 .icon-toggle:hover {
-  border-color: #667eea;
+  border-color: var(--primary-color);
 }
 
 /* Explicitly set SVG stroke via CSS to fix currentColor inheritance bug on older Android WebView */
@@ -1699,8 +1706,8 @@ body.dark-mode .search-highlight {
 }
 
 .icon-toggle.icon-toggle-checked {
-  background: #667eea;
-  border-color: #667eea;
+  background: var(--primary-color);
+  border-color: var(--primary-color);
   color: white;
   box-shadow: 0 0 12px rgba(102, 126, 234, 0.4);
 }
@@ -2039,7 +2046,7 @@ body {
 
 /* Drop zone highlighting */
 .task-list.drag-over {
-  border: 2px dashed var(--segment-color, #667eea);
+  border: 2px dashed var(--segment-color, var(--primary-color));
   background: linear-gradient(
     to bottom,
     rgba(var(--segment-color-rgb, 102, 126, 234), 0.05),
@@ -2196,13 +2203,30 @@ body {
 
 /* Accessibility: Focus indicators for keyboard navigation */
 .task-item:focus-visible {
-  outline: 2px solid #667eea;
+  outline: 2px solid var(--primary-color);
   outline-offset: 2px;
 }
 
 .task-list:focus-visible {
-  outline: 2px dashed #667eea;
+  outline: 2px dashed var(--primary-color);
   outline-offset: 4px;
+}
+
+/* Clearer drag feedback between quadrants (Issue #352 B3):
+   dim non-target segments and lift the one currently under the drag. */
+body.is-dragging .segment {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+body.is-dragging .segment:not(.drag-target-segment) {
+  opacity: 0.55;
+}
+
+.segment.drag-target-segment {
+  opacity: 1;
+  transform: scale(1.01);
 }
 
 /* ============================================
@@ -2380,8 +2404,8 @@ body.dark-mode .segment.keyboard-target::before {
   width: 100%;
   padding: 8px 12px;
   background: transparent;
-  color: #667eea;
-  border: 1.5px solid #667eea;
+  color: var(--primary-color);
+  border: 1.5px solid var(--primary-color);
   border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
@@ -2402,13 +2426,13 @@ body.dark-mode .segment.keyboard-target::before {
 }
 
 .btn.active {
-  background: #667eea;
+  background: var(--primary-color);
   color: white;
-  border-color: #667eea;
+  border-color: var(--primary-color);
 }
 
 .btn:visited {
-  color: #667eea;
+  color: var(--primary-color);
 }
 
 /* Toggle group: row of equal-width toggle buttons */
@@ -2438,9 +2462,9 @@ body.dark-mode .btn:hover {
 }
 
 body.dark-mode .btn.active {
-  background: #667eea;
+  background: var(--primary-color);
   color: white;
-  border-color: #667eea;
+  border-color: var(--primary-color);
 }
 
 .settings-separator {
@@ -2573,7 +2597,7 @@ body.dark-mode .settings-warning {
 }
 
 .undo-toast-btn {
-  background: #667eea;
+  background: var(--primary-color);
   color: white;
   border: none;
   padding: 6px 16px;
@@ -2707,7 +2731,7 @@ body.dark-mode .undo-toast {
 .tutorial-demo-task {
   background: var(--task-bg);
   border: 1px solid var(--border-color);
-  border-left: 3px solid #667eea;
+  border-left: 3px solid var(--primary-color);
   padding: 12px 16px;
   border-radius: 6px;
   font-size: 14px;
@@ -2717,7 +2741,7 @@ body.dark-mode .undo-toast {
 .tutorial-demo-arrow,
 .tutorial-demo-swipe {
   font-size: 32px;
-  color: #667eea;
+  color: var(--primary-color);
   animation: slide 1.5s ease-in-out infinite;
 }
 
@@ -2762,7 +2786,7 @@ body.dark-mode .undo-toast {
 }
 
 .tutorial-dot.active {
-  background: #667eea;
+  background: var(--primary-color);
   width: 24px;
   border-radius: 4px;
 }
@@ -2790,7 +2814,7 @@ body.dark-mode .undo-toast {
 }
 
 .tutorial-btn-primary {
-  background: #667eea;
+  background: var(--primary-color);
   color: white;
 }
 
@@ -2952,6 +2976,82 @@ body.focus-mode .segments {
 }
 
 /* ============================================================
+   Onboarding: Empty States & Demo Tasks (Issue #352 B2)
+   ============================================================ */
+
+.segment-empty-state {
+  border-radius: 8px;
+  padding: 12px;
+  text-align: center;
+}
+
+.segment-empty-message {
+  color: var(--text-light);
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 8px 4px;
+}
+
+.segment-demo-task {
+  position: relative;
+  background: var(--task-bg);
+  border: 1.5px dashed var(--grid-color);
+  text-align: left;
+}
+
+.segment-demo-badge {
+  display: inline-block;
+  background: var(--hover-bg);
+  color: var(--primary-color);
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-bottom: 6px;
+}
+
+.segment-demo-text {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+
+.segment-empty-explanation {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  padding-right: 20px;
+}
+
+.segment-demo-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-light);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.segment-demo-dismiss:hover {
+  background: var(--hover-bg);
+  color: var(--primary-color);
+}
+
+/* ============================================================
    UX Animations (Issue #242)
    All wrapped in prefers-reduced-motion guard at the bottom.
    ============================================================ */
@@ -3001,6 +3101,43 @@ body.focus-mode .segments {
   animation: taskFadeIn 0.18s ease-out both;
 }
 
+/* --- "Done!" completion micro-interaction (Issue #352 B3) --- */
+@keyframes taskCompletePulse {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.015);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes taskCompleteCheckGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--primary-rgb), 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 8px rgba(var(--primary-rgb), 0);
+  }
+}
+
+.task-completing {
+  animation: taskCompletePulse 0.22s ease-out both;
+}
+
+.task-completing .task-checkbox {
+  animation: taskCompleteCheckGlow 0.3s ease-out both;
+  border-radius: 4px;
+}
+
+.task-completing .task-text {
+  text-decoration: line-through;
+  opacity: 0.65;
+  transition: opacity 0.18s ease-out;
+}
+
 /* --- Modal slide-up --- */
 @keyframes modalSlideUp {
   from {
@@ -3047,6 +3184,19 @@ body.focus-mode .segments {
   .segment-add-btn:active,
   .settings-btn:active,
   .category-switch-btn:active {
+    transform: none;
+  }
+
+  .task-completing,
+  .task-completing .task-checkbox {
+    animation: none;
+  }
+
+  body.is-dragging .segment {
+    transition: none;
+  }
+
+  .segment.drag-target-segment {
     transform: none;
   }
 }

--- a/tests/unit/onboarding.test.js
+++ b/tests/unit/onboarding.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for onboarding.js module (Issue #352 B2)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isOnboardingDismissed,
+  dismissOnboarding,
+  isSegmentDemoDismissed,
+  dismissSegmentDemo,
+  shouldShowSegmentDemo,
+} from '../../js/modules/onboarding.js';
+
+describe('Onboarding Module', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isOnboardingDismissed / dismissOnboarding', () => {
+    it('is not dismissed by default', () => {
+      expect(isOnboardingDismissed()).toBe(false);
+    });
+
+    it('becomes dismissed after dismissOnboarding()', () => {
+      dismissOnboarding();
+      expect(isOnboardingDismissed()).toBe(true);
+    });
+  });
+
+  describe('isSegmentDemoDismissed / dismissSegmentDemo', () => {
+    it('is not dismissed by default', () => {
+      expect(isSegmentDemoDismissed(1)).toBe(false);
+    });
+
+    it('dismisses only the given segment', () => {
+      dismissSegmentDemo(1);
+      expect(isSegmentDemoDismissed(1)).toBe(true);
+      expect(isSegmentDemoDismissed(2)).toBe(false);
+    });
+
+    it('dismisses onboarding entirely once all demo segments are dismissed', () => {
+      dismissSegmentDemo(1);
+      dismissSegmentDemo(2);
+      dismissSegmentDemo(3);
+      expect(isOnboardingDismissed()).toBe(false);
+      dismissSegmentDemo(4);
+      expect(isOnboardingDismissed()).toBe(true);
+    });
+
+    it('tolerates corrupt localStorage content', () => {
+      localStorage.setItem('onboardingDemoDismissed', 'not-json');
+      expect(isSegmentDemoDismissed(1)).toBe(false);
+      expect(() => dismissSegmentDemo(1)).not.toThrow();
+      expect(isSegmentDemoDismissed(1)).toBe(true);
+    });
+  });
+
+  describe('shouldShowSegmentDemo', () => {
+    it('shows the demo for an untouched segment 1-4', () => {
+      expect(shouldShowSegmentDemo(1)).toBe(true);
+    });
+
+    it('never shows a demo for segment 5 (Done)', () => {
+      expect(shouldShowSegmentDemo(5)).toBe(false);
+    });
+
+    it('hides the demo once onboarding is dismissed', () => {
+      dismissOnboarding();
+      expect(shouldShowSegmentDemo(1)).toBe(false);
+    });
+
+    it('hides the demo once that segment was individually dismissed', () => {
+      dismissSegmentDemo(2);
+      expect(shouldShowSegmentDemo(2)).toBe(false);
+      expect(shouldShowSegmentDemo(1)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Beschreibung

Setzt die Punkte **B1**, **B2** und **B3** aus Issue #352 (Strategie: optische/UX-Aufwertung) um:

- **B1 – Design-Tokens konsolidieren:** `--primary-color`, `--primary`, `--primary-rgb` und `--hover-bg` sind jetzt echte Tokens in `:root` (statt toter `var()`-Referenzen, siehe alte Notiz in `CLAUDE.md`). Alle Literal-Hex-Vorkommen von `#667eea` in `style.css` wurden durch `var(--primary-color)` ersetzt.
- **B2 – Onboarding & Empty States:** Neues Modul `js/modules/onboarding.js`. Solange die Matrix komplett leer ist, zeigt jedes leere Segment 1–4 einen dismissbaren Beispiel-Task mit kurzer Quadranten-Erklärung statt einer Modal-Wall. Nach dem ersten echten Task oder sobald alle vier Demo-Tasks weggeklickt wurden, ist Onboarding dauerhaft beendet (localStorage). Danach zeigen leere Segmente (inkl. „Fertig!") freundliche Empty-State-Texte statt einfach nichts.
- **B3 – Micro-Interactions & Motion:** Kurze Puls-/Glow-Animation beim Abhaken einer Aufgabe, bevor sie nach „Fertig!" wandert. Klareres Drag-Feedback: Nicht-Ziel-Quadranten werden während des Ziehens gedimmt, der Zielquadrant hervorgehoben – für Touch- und Desktop-Drag-Pfad. Alles respektiert `prefers-reduced-motion`.

`CLAUDE.md` wurde entsprechend aktualisiert (neuer Abschnitt + veraltete Eigenheiten-Notiz zu den toten CSS-Variablen entfernt).

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [x] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [ ] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reines PWA-Frontend (`js/modules/*.js`, `script.js`, `style.css`, `translations.js`), keine Android/TWA-Änderungen.

## Testing Checklist

- [x] Lokaler Build/Tests erfolgreich (`npm test`, 205/205 Tests grün, Coverage weiter ≥ 80 %)
- [x] Keine ESLint-Fehler (`npm run lint`)
- [x] Keine Prettier-Abweichungen (`npm run format:check`)
- [x] Manuell im Browser verifiziert (Guest-Modus): leere Matrix mit Demo-Tasks/Erklärungen, Dismiss-Button, Übergang zu freundlichen Empty States nach erstem echten Task, „Erledigt"-Animation, Drag-Dimming

## Zusätzliche Notizen

Deckt die restlichen Punkte aus Issue #352 Abschnitt B (B4 Matrix-Lesbarkeit/Accessibility, B5 Brand-Auffrischung) bewusst nicht ab — die bleiben offen für spätere PRs, wie im Issue als Dachplanung vorgesehen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7MY1c9spbkyoJz8BAWVWR)_