### PR TITLE
fix: Cloud-Backup-Ursache (#355) + CI-Concurrency (#330)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -20,6 +20,10 @@ on:
       - 'Android/**'
       - '.github/workflows/build-android.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   actions: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cleanup:
     name: 🧹 Clean Old Caches

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================================================
   # JOB 1: Code Quality & Linting

--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -14,6 +14,10 @@ permissions:
   pull-requests: write
   statuses: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   mergeability:
     uses: S540d/project-templates/.github/workflows/reusable-mergeability.yml@v2

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,6 +20,10 @@ permissions:
   contents: write
   statuses: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-review:
     if: github.event.label.name == 'ai-review'

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   security-scan:
     uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ Das „Neue Aufgabe"-Fenster (`#quickAddModal` in `index.html`, geöffnet via `o
 - **Hinzufügen**-Button entfernt; stattdessen ein **OK**-Button (`#quickAddSubmitBtn`, Text aus `lang.buttons.ok`) direkt neben dem Eingabefeld (`.quick-add-input-row`).
 - Neuer i18n-Key `buttons.ok` (de/en) in `translations.js`.
 
+### Cloud-Backup: Storage-Rules-Pfad-Mismatch + Fehler-Tracking (Issue #355)
+
+Der Bug-Report „Cloud-Backup schlägt wieder fehl" kam ohne Repro-Details (Backup-Fehler landen nur in `console.error`, nirgends sonst sichtbar). Zwei konkrete Bugs dazu behoben:
+
+- **`docs/FIREBASE_SECURITY_RULES.md` dokumentierte einen falschen Storage-Pfad:** `match /backups/{userId}/{backupFile}`, während `uploadBackup()` in `js/modules/backup.js` tatsächlich nach `users/{userId}/backups/{filename}` schreibt. Da Storage-Rules laut Doku nur über die Firebase Console gepflegt werden (nicht im Repo), führt dieser Pfad-Mismatch dazu, dass die Regel nie greift und jeder Upload auf die Deny-all-Regel fällt (`permission-denied`). Doku korrigiert (Pfad + Troubleshooting-Hinweis); die **Regel muss zusätzlich in der Firebase Console für alle drei Projekte (production/staging/testing) manuell auf den korrigierten Pfad aktualisiert werden** – das kann Claude Code nicht selbst deployen.
+- **Keine Fehler-Sichtbarkeit:** Backup-Fehler (manuell wie automatisch) gingen nur in die Browser-Konsole, nicht an Sentry. Neue Funktion `reportBackupError()` in `backup.js` meldet Fehler jetzt an `window.errorTracker.captureException()` (Sentry-Hook aus `sentry.js`), sodass künftige Fehlschläge (Ursache, Stacktrace) in Sentry auswertbar sind statt nur in Nutzer-Devtools.
+
 ### Kategorien / Kalender-Umschalter (Issue #198 + #259, PR #260)
 
 Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` oder `'business'` (siehe `filterByCategory` in `js/modules/tasks.js`). Aufgaben ohne Kategorie werden beim Filtern wie `'private'` behandelt.
@@ -147,6 +154,8 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 
 ### Kürzlich erledigt
 
+- **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes
+- **#355** – Cloud-Backup-Fix: falschen Storage-Rules-Pfad in `docs/FIREBASE_SECURITY_RULES.md` korrigiert (`users/{userId}/backups/...` statt `backups/{userId}/...`) + Backup-Fehler werden jetzt an Sentry gemeldet (`reportBackupError()` in `backup.js`), siehe Abschnitt „Cloud-Backup" oben. **Firebase-Console-Regel muss noch manuell auf allen drei Projekten aktualisiert werden.**
 - **#352 B1–B3** – Design-Tokens konsolidiert (`--primary-color`/`--primary`/`--primary-rgb`/`--hover-bg` echt definiert), Onboarding mit dismissable Demo-Tasks + Quadranten-Erklärung + freundlichen Empty States (`js/modules/onboarding.js`), „Erledigt"-Micro-Interaction + klareres Drag-Feedback (Segment-Dimming), siehe Abschnitt „Design-Tokens, Onboarding & Micro-Interactions" oben
 - **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt
 - **#179** – Export CSV/Markdown, Smart Suggest (Quadrant-Vorschlag), Matrix-Verteilung in Metriken (PR #332, gemerged 2026-06-19)

--- a/docs/FIREBASE_SECURITY_RULES.md
+++ b/docs/FIREBASE_SECURITY_RULES.md
@@ -174,7 +174,12 @@ service firebase.storage {
     }
 
     // User backup files
-    match /backups/{userId}/{backupFile} {
+    // NOTE: Path must match js/modules/backup.js exactly (`users/{userId}/backups/{filename}`).
+    // A mismatch here (e.g. `backups/{userId}/...`) means the rule never
+    // actually applies to the app's real upload path, and every write falls
+    // through to the deny-all rule below — backups then fail with
+    // "permission-denied" no matter how the rule body looks (Issue #355).
+    match /users/{userId}/backups/{backupFile} {
       // Allow read if authenticated and owner
       allow read: if isAuthenticated() && isOwner(userId);
 
@@ -214,7 +219,7 @@ service firebase.storage {
 
 ```javascript
 // Testing/Staging: Increased file size limits
-match /backups/{userId}/{backupFile} {
+match /users/{userId}/backups/{backupFile} {
   allow write: if isAuthenticated()
                 && isOwner(userId)
                 && request.resource.size < 10 * 1024 * 1024; // 10MB for testing
@@ -398,6 +403,10 @@ npm run test:firebase-rules
 1. User not authenticated → Check `request.auth != null`
 2. User trying to access another user's data → Check `isOwner(userId)`
 3. Data validation failed → Check task structure matches schema
+4. Storage rule path doesn't match the app's actual upload path → For backups,
+   the deployed Storage rule must match `users/{userId}/backups/{backupFile}`
+   exactly (see `uploadBackup()` in `js/modules/backup.js`); any other path
+   pattern silently falls through to the deny-all rule (Issue #355)
 
 **Debug:**
 ```javascript
@@ -453,8 +462,8 @@ allow read: if debug(isAuthenticated()) && debug(isOwner(userId));
 
 ---
 
-**Version:** 1.0.0
-**Last Updated:** 2026-01-29
+**Version:** 1.0.1
+**Last Updated:** 2026-07-12
 **Maintainer:** S540d
 
 **⚠️ CRITICAL:** After any rule changes, always deploy to Testing → Staging → Production in that order. Never deploy untested rules to Production.

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -80,11 +80,34 @@ export async function uploadBackup(
     return filename;
   } catch (error) {
     console.error('Backup upload failed:', error);
+    reportBackupError(error, userId);
     if (showNotification) {
       const message = currentLanguage === 'de' ? 'Backup fehlgeschlagen' : 'Backup failed';
       showError(message);
     }
     throw error;
+  }
+}
+
+/**
+ * Report a backup failure to the configured error tracker (Sentry), if any.
+ * Auto-backup failures are otherwise only logged to the console (see
+ * `showNotification` above), so without this, the actual cause (e.g. a
+ * Storage Rules permission mismatch) is invisible outside the user's devtools.
+ * @param {Error} error - The error that occurred
+ * @param {string} userId - User ID the backup was attempted for
+ */
+function reportBackupError(error, userId) {
+  if (typeof window === 'undefined') return;
+  if (typeof window.errorTracker?.captureException !== 'function') return;
+
+  try {
+    window.errorTracker.captureException(error, {
+      context: { operation: 'uploadBackup', userId },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (_trackingError) {
+    // Tracking failure must not interrupt application flow
   }
 }
 

--- a/tests/unit/backup.test.js
+++ b/tests/unit/backup.test.js
@@ -100,6 +100,36 @@ describe('Backup Module', () => {
       );
     });
 
+    it('should report failures to window.errorTracker when configured', async () => {
+      const { uploadBytes } = await import('firebase/storage');
+      const mockError = new Error('storage/unauthorized');
+      uploadBytes.mockRejectedValueOnce(mockError);
+      window.errorTracker = { captureException: vi.fn() };
+
+      try {
+        await uploadBackup(mockStorage, mockUserId, mockTasks, 'en');
+      } catch (error) {
+        // Expected to throw
+      }
+
+      expect(window.errorTracker.captureException).toHaveBeenCalledWith(
+        mockError,
+        expect.objectContaining({ context: { operation: 'uploadBackup', userId: mockUserId } })
+      );
+
+      delete window.errorTracker;
+    });
+
+    it('should not throw when window.errorTracker is not configured', async () => {
+      const { uploadBytes } = await import('firebase/storage');
+      uploadBytes.mockRejectedValueOnce(new Error('Upload failed'));
+      delete window.errorTracker;
+
+      await expect(uploadBackup(mockStorage, mockUserId, mockTasks, 'en')).rejects.toThrow(
+        'Upload failed'
+      );
+    });
+
     it('should validate required parameters', async () => {
       await expect(uploadBackup(null, mockUserId, mockTasks, 'en')).rejects.toThrow(
         'Storage and userId are required'


### PR DESCRIPTION
# Pull Request

## Beschreibung

Setzt Issue #355 (Cloud-Backup schlägt fehl) und Issue #330 (CI-Concurrency) um.

**#355 – Cloud-Backup:**
- `docs/FIREBASE_SECURITY_RULES.md` dokumentierte den Storage-Pfad `backups/{userId}/{backupFile}`, während `uploadBackup()` in `js/modules/backup.js` tatsächlich nach `users/{userId}/backups/{filename}` schreibt. Dieser Pfad-Mismatch führt dazu, dass die dokumentierte Storage-Rule den echten Upload-Pfad nie trifft und jeder Schreibversuch auf die Deny-all-Regel fällt (`permission-denied`). Pfad in der Doku korrigiert + Troubleshooting-Hinweis ergänzt.
  - ⚠️ **Die Storage-Rule muss zusätzlich manuell in der Firebase Console für alle drei Projekte (production/staging/testing) aktualisiert werden** – Security Rules liegen laut Doku nicht im Repo und können von Claude Code nicht deployt werden.
- Backup-Fehler (manuell wie automatisch) landeten bisher nur in `console.error`, ohne jede Fehler-Sichtbarkeit für Diagnose. Neue `reportBackupError()` in `backup.js` meldet Fehler jetzt an `window.errorTracker` (Sentry-Hook aus `js/modules/sentry.js`), damit künftige Fehlschläge in Sentry auswertbar sind.

**#330 – CI-Doppelläufe vermeiden:**
- `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` ergänzt in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` (Vorlage: bereits vorhandenes `deploy-unified.yml`). Verhindert parallele, überholte CI-Läufe bei schnell aufeinanderfolgenden Pushes auf denselben Branch.

## Art der Änderung

- [x] Bugfix (non-breaking change)
- [x] Dokumentation Update

## Testing Checklist

- [x] `npm test` (207/207 Tests grün, exkl. `storage.test.js`)
- [x] `npm run lint` (keine neuen Errors/Warnings in geänderten Dateien)
- [x] `npm run format:check`
- [x] Alle 6 geänderten Workflow-YAMLs auf gültige Syntax geprüft (`yaml.safe_load`)

## Zusätzliche Notizen

Issue #355 hatte keine Beschreibung/Repro-Steps. Root Cause wurde durch Code-Archäologie ermittelt: der Storage-Pfad in `backup.js` (`users/{userId}/backups/...`) existiert unverändert seit Einführung des Backup-Moduls, während `docs/FIREBASE_SECURITY_RULES.md` von Anfang an einen anderen Pfad dokumentierte (`backups/{userId}/...`). Die vorherige CSP-Fix-Runde (#339/#340) hat ein anderes, echtes Problem behoben, aber offenbar nicht dieses. Da die tatsächlich deployten Firebase-Console-Regeln nicht einsehbar sind, ist dies die plausibelste Ursache, aber keine 100%ige Verifikation ohne Zugriff auf die Firebase Console – bitte nach Deploy der korrigierten Regel bestätigen, ob das Backup wieder funktioniert.

CLAUDE.md wurde für beide Issues aktualisiert (neuer Abschnitt „Cloud-Backup: Storage-Rules-Pfad-Mismatch + Fehler-Tracking" + Einträge unter „Kürzlich erledigt").
