### PR TITLE
feat: SEO basics for landing page (S540d/project-templates#95)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,23 @@
     />
     <title>Eisenhauer Matrix</title>
 
+    <!-- SEO -->
+    <meta
+      name="description"
+      content="Eisenhauer Matrix is a free Progressive Web App for task management based on the Eisenhower Matrix method. Organize tasks by urgency and importance, with recurring tasks, offline support, and cross-device sync."
+    />
+    <meta name="robots" content="index, follow" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Eisenhauer Matrix" />
+    <meta
+      property="og:description"
+      content="A free Progressive Web App for task management based on the Eisenhower Matrix method. Organize tasks by urgency and importance, with recurring tasks, offline support, and cross-device sync."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://s540d.github.io/Eisenhauer/" />
+    <meta property="og:image" content="https://s540d.github.io/Eisenhauer/icons/icon-512x512.png" />
+
     <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://s540d.github.io/Eisenhauer/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://s540d.github.io/Eisenhauer/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add `<meta name="description">`, `<meta name="robots" content="index, follow">`, and Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`) to `index.html`
- Add `public/robots.txt` allowing all crawlers and pointing to the sitemap
- Add `public/sitemap.xml` with a single entry for the deployed root page (`https://s540d.github.io/Eisenhauer/`)

Vite copies everything under `public/` to `dist/` root by default (no `publicDir` override in `vite.config.js`), so `robots.txt` and `sitemap.xml` land at the deployed root alongside `index.html`. Verified via a local `npm run build` — both files and all new meta tags are present in `dist/`.

Part of S540d/project-templates#95 (this PR covers the Eisenhauer portion only; other apps in that issue are handled in their own repos).

## Test plan
- [x] `npm run lint` — passes (pre-existing unrelated warnings only)
- [x] `npm run build` — succeeds, `dist/robots.txt`, `dist/sitemap.xml`, and new meta/OG tags confirmed present in `dist/index.html`
- [x] `npx vitest run --exclude="tests/unit/storage.test.js"` — 205/205 tests pass
- [x] Manually reviewed `index.html` diff — only intended SEO additions, no unrelated changes