### PR TITLE
Android: Ziel-API-Level auf 36 (Android 16) anheben

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 
 android {
     namespace 'com.sven4321.eisenhauer'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
-        targetSdk 35
-        versionCode 25
+        targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
+        versionCode 26
         versionName "1.12.1"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.7.0' apply false
+    id 'com.android.application' version '8.9.1' apply false
 }
 
 task clean(type: Delete) {

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Beschreibung

Google Play meldet, dass Apps auf ein zu altes Ziel-API-Level ausgerichtet sind und bis zum **31.08.2026** die Anforderungen erfüllen müssen. Die Anforderung für diesen Stichtag ist **API-Level 36 (Android 16)**.

Die TWA war auf `targetSdk`/`compileSdk` **35** konfiguriert und wurde daher als nicht-konform markiert. Dieser PR hebt das Ziel-API-Level auf **36** an und aktualisiert die Toolchain entsprechend.

Änderungen (`Android/`):
- `compileSdk` / `targetSdk` **35 → 36** in `app/build.gradle` (deckt alle Flavors `prod`/`staging`/`beta` ab, die sich die `defaultConfig` teilen — die von Google gemeldeten „2 Apps" sind veröffentlichte Flavors)
- Android Gradle Plugin **8.7.0 → 8.9.1** (offizielle SDK-36-Unterstützung)
- Gradle Wrapper **8.11 → 8.11.1** (Mindestanforderung für AGP 8.9)
- `versionCode` **25 → 26** für den neuen Play-Store-Upload

Entspricht dem in `.templates` dokumentierten Standard (`compileSdk`/`targetSdk = 36`).

## Art der Änderung

- [x] Bugfix (non-breaking change) — Compliance-Fix für Google Play
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [ ] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reine Android-Build-Konfiguration (Gradle), kein App-/JS-Code.

## Testing Checklist

- [ ] Lokaler Build erfolgreich (`./gradlew bundleRelease`) — im CI-Build zu verifizieren (kein Android-SDK in dieser Session)
- [x] Keine App-Code-Änderungen (nur Build-Konfiguration)
- [x] Geänderte Werte entsprechen dem Projekt-Standard aus `.templates`

## Zusätzliche Notizen

- TWA-Verhalten ändert sich durch den Target-Bump nicht wesentlich; der `androidbrowserhelper`-`LauncherActivity` ist ein dünner Browser-Wrapper. Android-16-Edge-to-Edge wird über die Browser-Helper-Ebene behandelt.
- Nach dem Merge und einem neuen Build/Upload sollte die Play-Store-Warnung für beide gemeldeten Flavors verschwinden. Gemäß Projektregel bitte einen Git-Tag nach dem Play-Store-Upload setzen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQhPtGTV4dVfH7xuzMSH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpQhPtGTV4dVfH7xuzMSH2)_