### PR TITLE
testing → main: SEO-Basics + Android Target-API 36

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 
 android {
     namespace 'com.sven4321.eisenhauer'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
-        targetSdk 35
-        versionCode 25
+        targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
+        versionCode 26
         versionName "1.12.1"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.7.0' apply false
+    id 'com.android.application' version '8.9.1' apply false
 }
 
 task clean(type: Delete) {

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/index.html
+++ b/index.html
@@ -8,6 +8,23 @@
     />
     <title>Eisenhauer Matrix</title>
 
+    <!-- SEO -->
+    <meta
+      name="description"
+      content="Eisenhauer Matrix is a free Progressive Web App for task management based on the Eisenhower Matrix method. Organize tasks by urgency and importance, with recurring tasks, offline support, and cross-device sync."
+    />
+    <meta name="robots" content="index, follow" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Eisenhauer Matrix" />
+    <meta
+      property="og:description"
+      content="A free Progressive Web App for task management based on the Eisenhower Matrix method. Organize tasks by urgency and importance, with recurring tasks, offline support, and cross-device sync."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://s540d.github.io/Eisenhauer/" />
+    <meta property="og:image" content="https://s540d.github.io/Eisenhauer/icons/icon-512x512.png" />
+
     <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://s540d.github.io/Eisenhauer/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://s540d.github.io/Eisenhauer/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Zusammenfassung

Promotet den aktuellen `testing`-Stand nach `main` (production).

### Enthaltene Änderungen
- **SEO-Basics** (#95, PR #362): Meta-Description, Open Graph Tags, `robots.txt`, `sitemap.xml`
- **Android Ziel-API-Level 36** (Android 16, PR #363): Google-Play-Anforderung

## Test-Hinweis
Manueller Test auf `testing` erfolgt. Merge nach `main` erst nach expliziter Freigabe und grüner CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)