### PR TITLE
chore: aab-archive/ zu .gitignore hinzufügen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ coverage/
 credentials.json
 *.p12
 *.p8
+aab-archive/


### PR DESCRIPTION
Lokales AAB-Archiv-Verzeichnis aus Git ausschließen (AABs ~1.9M, gehören nie in die History).

🤖 Generated with [Claude Code](https://claude.com/claude-code)