### PR TITLE
Docs: Ideenskizze für Notizfunktion

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
-        versionCode 26
-        versionName "1.12.1"  // Match PWA version
+        versionCode 27
+        versionName "1.12.2"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/docs/NOTES_FEATURE_CONCEPT.md
+++ b/docs/NOTES_FEATURE_CONCEPT.md
@@ -1,0 +1,54 @@
+# Ideenskizze: Notizfunktion
+
+Status: Konzept / Ideenskizze — keine Implementierung, dient als Grundlage für ein späteres Issue.
+
+## Kontext
+
+Die App bietet aktuell keine Möglichkeit, längere Freitext-Notizen festzuhalten – Tasks haben nur einen kurzen Titel (max. 140 Zeichen, `MAX_TASK_LENGTH` in `js/modules/config.js`). Ein separates Notiz-Feld pro Task existiert bislang nicht (verifiziert per Code-Suche in `tasks.js`, `ui.js`). Ziel: eine **einfache, abschaltbare Ergänzung**, mit der man (a) zu einzelnen Tasks kurze Notizen ergänzen und (b) freistehende Notizen ganz ohne Task-Bezug sammeln kann – bewusst ohne Formatierung, Tags, Verknüpfungen o. ä. ("kein Schnickschnack").
+
+## Grundidee
+
+Eine neue, optionale **Notizen-Sammlung** – technisch und UI-seitig unabhängig von der Matrix, aber mit optionaler Verknüpfung zu einem Task:
+
+- **Freistehende Notizen**: eigener Menüpunkt/Icon (analog zu Metriken/Export), öffnet ein Modal mit einfacher Liste (Text + Erstellungsdatum), Notiz hinzufügen/löschen. Kein Editieren-Dialog mit Rich-Text – nur ein Textfeld.
+- **Task-Notizen**: optionales Freitextfeld im Quick-Add-/Edit-Dialog eines Tasks ("Notiz"-Textarea). Ist die Task-Notiz gesetzt, taucht sie automatisch auch in der Notizen-Sammlung auf (mit Verweis/Badge „zu Task: …"), muss aber nicht doppelt gepflegt werden – sie liegt technisch nur einmal auf dem Task-Objekt.
+
+Damit bleibt es bei **einer** Datenquelle: freistehende Notizen sind eigene Objekte in einer neuen `notes`-Collection, Task-Notizen sind ein Feld auf dem Task-Objekt. Die Notizen-Ansicht liest beide Quellen zusammen und zeigt sie in einer flachen, chronologisch sortierten Liste.
+
+## Feature-Flag (abschaltbar) – nur für die Notizen-Sammlungsansicht
+
+Wichtige Präzisierung: **Nur die separate Notizen-Übersicht** (freistehende Sammlung aller Notizen) hängt am Flag. Die Möglichkeit, eine Notiz direkt an einem Task zu ergänzen (Freitextfeld im Quick-Add-/Edit-Dialog), ist **immer verfügbar** – unabhängig vom Toggle, wie jedes andere reguläre Task-Feld (z. B. Fälligkeitsdatum).
+
+- Neuer Key `STORAGE_KEYS_EXTENDED.NOTES_COLLECTION_ENABLED = 'notesCollectionEnabled'` in `js/modules/config.js` (neben `SMART_FUNCTIONS_ENABLED`)
+- Toggle im Personalisieren-Modal (`index.html`, neue `.settings-section` direkt nach dem Smarte-Funktionen-Block), gleicher Checkbox+Label+Beschreibung-Aufbau. Beschreibungstext macht klar, dass er nur die Übersicht betrifft (z. B. „Zeigt eine gesammelte Übersicht aller Notizen an").
+- Wiring in `js/modules/ui.js` analog zum bestehenden Smart-Functions-Toggle (Zustand beim Öffnen reflektieren, Klick-Handler → `localStorage.setItem('notesCollectionEnabled', ...)`)
+- Konsum-Stelle prüft `localStorage.getItem('notesCollectionEnabled') === 'true'` direkt am Ort der Verwendung (kein zentraler Helper – entspricht bestehendem Stil): steuert **ausschließlich** die Sichtbarkeit des Notizen-Icons/Menüpunkts, der die Sammlungs-Ansicht öffnet.
+- Das Notiz-Textfeld im Quick-Add-/Edit-Dialog wird **nicht** vom Flag verborgen – es ist Teil des normalen Task-Formulars.
+- **Deaktiviert = Standard** für die Sammlungsansicht. Task-Notizen bleiben davon unberührt: sie werden weiter gespeichert und sind über den Task selbst sichtbar/editierbar, auch wenn die Übersicht ausgeblendet ist. Kein Datenverlust beim Umschalten.
+
+## Datenmodell
+
+- Task-Objekt (`createTaskObject`, `js/modules/tasks.js`) bekommt optionales Feld `notes` (string), analog zu `dueDate`/`category` nur gesetzt wenn nicht leer. Bearbeitung über `updateTask()`.
+- Neue eigenständige Notiz: `{ id, text, createdAt }` – bewusst minimal, keine Kategorien/Tags/Prioritäten.
+- Persistenz folgt dem bestehenden Speicherpfad: Guest-Mode über LocalForage (`storage.js`, neuer Key z. B. `eisenhauerNotes` analog `eisenhauerTasks`), authentifizierter Modus über Firestore (analog `saveTaskToFirestore`/`loadUserTasks`) in eigener Collection `notes`. Task-gebundene Notizen brauchen keinen neuen Storage-Pfad, da sie im Task-Dokument mitlaufen.
+
+## UI-Bausteine (minimal)
+
+- Neuer Menüpunkt „Notizen" (Icon im Header oder Settings-Modal unter „Daten")
+- Ein Modal: Liste aller Notizen (Text, Datum, ggf. „→ Task XY"-Hinweis bei Task-Notizen), Eingabefeld + „Hinzufügen" oben, Löschen-Icon pro Eintrag. Keine Suche, kein Filter, keine Sortier-Optionen in v1.
+- Quick-Add-Dialog: optionales Textarea „Notiz" unterhalb des Titel-Inputs, **immer sichtbar**, unabhängig vom Flag.
+
+## i18n
+
+Neue Keys in `js/modules/translations.js` (de/en), analog zum bestehenden `personalize.smartFunctions*`-Block: z. B. `notes.title`, `notes.placeholder`, `notes.empty`, `personalize.notesCollectionEnabled`, `personalize.notesCollectionEnabledDesc`. Anwendung in `updateLanguageUI()`.
+
+## Bewusst nicht in v1
+
+- Kein Rich-Text/Markdown, keine Bilder/Anhänge
+- Keine Verschlagwortung, keine Verknüpfung zu mehreren Tasks
+- Keine Volltextsuche (bei Bedarf später ergänzbar, kein Blocker)
+- Kein separater Export – bestehender CSV/Markdown-Export (`export.js`) könnte Notizen später mit aufnehmen, ist aber nicht Teil dieser Ideenskizze
+
+## Nächste Schritte (falls gewünscht)
+
+Bei Zustimmung: Issue anlegen (Titel z. B. „Notizfunktion (Task-Notizen + freistehende Notizen-Sammlung)"), Umsetzung als Feature-Branch gegen `testing`, Tests für `createTaskObject`/`updateTask`-Erweiterung und für die neue Notizen-Modul-Logik.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eisenhauer-matrix",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Eine moderne, mobile-first Progressive Web App zur Aufgabenverwaltung nach der Eisenhauer-Matrix-Methode.",
   "main": "index.html",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fügt `docs/NOTES_FEATURE_CONCEPT.md` als Ideenskizze für eine neue Notizfunktion hinzu
- Kein Code, reine Konzept-Dokumentation als Diskussionsgrundlage für ein späteres Issue

## Kernpunkte der Skizze

- **Task-Notizen**: neues optionales Freitextfeld pro Task (Quick-Add/Edit) – immer verfügbar, kein Feature-Flag
- **Notizen-Sammlung**: separate, freistehende Notizübersicht (unabhängig von Tasks), hinter einem abschaltbaren Toggle (`notesCollectionEnabled`), analog zum bestehenden „Smarte Funktionen"-Muster
- Bewusst minimal: kein Rich-Text, keine Tags, keine Verknüpfung zu mehreren Tasks, keine Volltextsuche in v1
- Datenmodell/Storage folgen bestehenden Mustern (`tasks.js`, `storage.js`, `translations.js`)

## Test plan

- [x] Reine Dokumentationsänderung, keine funktionalen Änderungen — `npm test` nicht erforderlich
- [ ] Review/Feedback zur Skizze einholen, danach ggf. Issue + Umsetzung als Folge-PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZct9LVPGA18VPKRTxMSqG)_