### PR TITLE
Notizfunktion: Task-Notizen + freistehende Notizen-Sammlung

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,6 +393,17 @@
           </label>
         </div>
 
+        <!-- Optional task notes (always visible, not gated by the notes-collection flag) -->
+        <div class="quick-add-notes-row">
+          <textarea
+            id="quickAddNotes"
+            class="quick-add-notes-input"
+            placeholder="Notiz (optional)"
+            maxlength="500"
+            rows="2"
+          ></textarea>
+        </div>
+
         <!-- Recurring Task Configuration -->
         <div id="quickRecurringOptions" class="recurring-options">
           <div class="recurring-option">
@@ -592,6 +603,13 @@
 
         <div class="settings-separator"></div>
 
+        <!-- Notizen Button (only visible when notesCollectionEnabled, Issue #371) -->
+        <div id="notesSection" class="settings-section" style="display: none">
+          <button id="notesBtn" class="btn">Notizen</button>
+        </div>
+
+        <div id="notesSeparator" class="settings-separator" style="display: none"></div>
+
         <!-- JSON Export & Import -->
         <div class="settings-section">
           <h4 id="dataManagementTitle" class="settings-section-title">DATEN</h4>
@@ -739,6 +757,21 @@
           </label>
           <p class="settings-info" id="smartFunctionsDesc">
             Automatisch Aufgaben als dringend markieren, wenn sie in 3 Tagen fällig sind
+          </p>
+        </div>
+
+        <div class="settings-separator"></div>
+
+        <!-- Notes Collection Settings (Issue #371) -->
+        <div class="settings-section">
+          <h4 class="settings-section-title" id="personalizeNotesCollectionTitle">NOTIZEN</h4>
+          <label class="smart-functions-toggle">
+            <input type="checkbox" id="notesCollectionToggle" />
+            <span id="notesCollectionLabel">Notizen-Übersicht aktivieren</span>
+          </label>
+          <p class="settings-info" id="notesCollectionDesc">
+            Zeigt einen „Notizen"-Menüpunkt für eine freie Notizliste unabhängig von Aufgaben.
+            Notizen an einzelnen Aufgaben bleiben davon unberührt.
           </p>
         </div>
 
@@ -911,6 +944,47 @@
           </div>
         </div>
         <button id="metricsCancelBtn" class="btn cancel-btn">Close</button>
+      </div>
+    </div>
+
+    <!-- Notes Modal (standalone notes collection, Issue #371) -->
+    <div id="notesModal" class="modal">
+      <div class="modal-content notes-modal">
+        <h3 id="notesModalTitle">Notizen</h3>
+
+        <div id="notesListContainer" class="notes-list-container"></div>
+
+        <div class="notes-add-row">
+          <input
+            type="text"
+            id="notesAddInput"
+            placeholder="Neue Notiz…"
+            maxlength="500"
+            autocomplete="off"
+          />
+          <button id="notesAddBtn" class="btn">Hinzufügen</button>
+        </div>
+
+        <button id="notesCancelBtn" class="btn cancel-btn">Close</button>
+      </div>
+    </div>
+
+    <!-- Edit Notes Modal (edit notes on an existing task, Issue #371) -->
+    <div id="editNotesModal" class="modal">
+      <div class="modal-content quick-add-modal">
+        <h3 id="editNotesTitle">Notiz bearbeiten</h3>
+        <p id="editNotesTaskName" class="quick-add-category"></p>
+
+        <textarea
+          id="editNotesTextarea"
+          class="quick-add-notes-input"
+          placeholder="Notiz (optional)"
+          maxlength="500"
+          rows="4"
+        ></textarea>
+
+        <button id="editNotesSaveBtn" class="btn">Save</button>
+        <button id="editNotesCancelBtn" class="btn cancel-btn">Cancel</button>
       </div>
     </div>
 

--- a/js/modules/config.js
+++ b/js/modules/config.js
@@ -21,6 +21,7 @@ export const COLORS = {
 
 export const STORAGE_KEYS = {
   TASKS: 'eisenhauer-tasks',
+  NOTES: 'eisenhauer-notes',
   LANGUAGE: 'language',
   DARK_MODE: 'darkMode',
   DRAG_HINT_SEEN: 'dragHintSeen',
@@ -28,6 +29,7 @@ export const STORAGE_KEYS = {
 
 export const UPDATE_CHECK_INTERVAL = 10000; // 10 seconds
 export const MAX_TASK_LENGTH = 140;
+export const MAX_NOTES_LENGTH = 500;
 
 // Smart Rules Configuration
 export const SMART_RULES = {
@@ -37,4 +39,5 @@ export const SMART_RULES = {
 export const STORAGE_KEYS_EXTENDED = {
   ...STORAGE_KEYS,
   SMART_FUNCTIONS_ENABLED: 'smartFunctionsEnabled',
+  NOTES_COLLECTION_ENABLED: 'notesCollectionEnabled',
 };

--- a/js/modules/notes.js
+++ b/js/modules/notes.js
@@ -1,0 +1,100 @@
+/**
+ * Notes Module
+ * Handles the standalone notes collection (independent of tasks)
+ */
+
+// Notes storage (flat, chronological array)
+export let notes = [];
+
+/**
+ * Generate a stable, collision-free note ID.
+ * Mirrors generateTaskId() in tasks.js for consistent ID semantics.
+ * @returns {string} Unique note ID
+ */
+export function generateNoteId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (older browsers/tests)
+  return `note-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Create a new note object
+ */
+function createNoteObject(text, createdAt = null, sourceTaskId = null) {
+  const note = {
+    id: generateNoteId(),
+    text,
+    createdAt: createdAt || Date.now(),
+  };
+
+  if (sourceTaskId) {
+    note.sourceTaskId = sourceTaskId;
+  }
+
+  return note;
+}
+
+/**
+ * Add a new note to the collection
+ * @param {string} text - Note text
+ * @param {function} saveCallback - Callback to save the note (Firebase or LocalStorage)
+ * @param {string} sourceTaskId - Optional ID of the task this note originated from
+ * @returns {object} The created note
+ */
+export function addNote(text, saveCallback = null, sourceTaskId = null) {
+  if (typeof text !== 'string') {
+    throw new TypeError('Note text must be a string');
+  }
+  if (text.trim().length === 0) {
+    throw new Error('Note text cannot be empty');
+  }
+  if (text.length > 500) {
+    throw new Error('Note text must not exceed 500 characters');
+  }
+
+  const note = createNoteObject(text.trim(), null, sourceTaskId);
+  notes.push(note);
+
+  if (saveCallback) {
+    saveCallback(note);
+  }
+
+  return note;
+}
+
+/**
+ * Delete a note by ID
+ * @param {string} noteId - ID of the note to delete
+ * @param {function} deleteCallback - Callback to persist the deletion
+ * @returns {object|null} The removed note, or null if not found
+ */
+export function deleteNote(noteId, deleteCallback = null) {
+  const index = notes.findIndex((n) => String(n.id) === String(noteId));
+  if (index === -1) return null;
+
+  const [removed] = notes.splice(index, 1);
+
+  if (deleteCallback) {
+    deleteCallback(removed);
+  }
+
+  return removed;
+}
+
+/**
+ * Get all notes
+ * @returns {Array} All notes
+ */
+export function getAllNotes() {
+  return notes;
+}
+
+/**
+ * Replace the entire notes collection (used after loading from storage)
+ * @param {Array} newNotes - Notes to set
+ */
+export function setAllNotes(newNotes) {
+  notes = Array.isArray(newNotes) ? newNotes : [];
+}

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -9,12 +9,14 @@ import { isGuestMode } from './auth.js';
 import { OfflineQueue } from './offline-queue.js';
 import { ErrorHandler } from './error-handler.js';
 import { showError, showInfo, showWarning } from './notifications.js';
+import { STORAGE_KEYS } from './config.js';
 import {
   collection,
   doc,
   getDocs,
   setDoc,
   deleteDoc,
+  deleteField,
   writeBatch,
   serverTimestamp,
 } from 'firebase/firestore';
@@ -247,6 +249,10 @@ export async function saveTaskToFirestore(task, userId, db) {
     taskData.category = task.category;
   }
 
+  if (task.notes) {
+    taskData.notes = task.notes;
+  }
+
   // Add to offline queue with retry logic and error handling
   try {
     await offlineQueue.add(
@@ -308,6 +314,12 @@ export async function updateTaskInFirestore(task, userId, db) {
     updateData.category = task.category;
   }
 
+  // setDoc uses merge:true below, so an omitted field would just keep its old
+  // value in Firestore. Notes are user-clearable (empty the textarea to
+  // remove a note), so an absent/empty value must explicitly delete the
+  // field rather than silently leaving a stale one behind.
+  updateData.notes = task.notes ? task.notes : deleteField();
+
   // Add to offline queue with retry logic
   await offlineQueue.add(
     'updateTask',
@@ -344,6 +356,131 @@ export async function deleteTaskFromFirestore(taskId, userId, db) {
     },
     {
       taskId,
+      userId,
+    },
+    3 // maxRetries
+  );
+}
+
+/**
+ * Save guest notes to LocalForage (IndexedDB)
+ * @param {Array} notes - Flat array of note objects
+ */
+export async function saveGuestNotes(notes) {
+  try {
+    await localforage.setItem(STORAGE_KEYS.NOTES, notes);
+  } catch (_error) {
+    // Guest note save failure is non-fatal; data remains in memory
+  }
+}
+
+/**
+ * Load guest notes from LocalForage
+ * @returns {Promise<Array>} Notes array
+ */
+export async function loadGuestNotes() {
+  try {
+    const notesData = await localforage.getItem(STORAGE_KEYS.NOTES);
+    return Array.isArray(notesData) ? notesData : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+/**
+ * Load user notes from Firestore
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ * @returns {Promise<Array>} Notes array
+ */
+export async function loadUserNotes(userId, db) {
+  if (!userId || !db) return [];
+
+  try {
+    const notesRef = collection(db, 'users', userId, 'notes');
+    const snapshot = await getDocs(notesRef);
+
+    const notes = [];
+    snapshot.forEach((docSnap) => {
+      const note = docSnap.data();
+      note.id = String(docSnap.id);
+      notes.push(note);
+    });
+
+    // Firestore doesn't guarantee order without an explicit orderBy query,
+    // so sort client-side to keep the collection chronological.
+    notes.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+
+    return notes;
+  } catch (_error) {
+    return [];
+  }
+}
+
+/**
+ * Save a single note to Firestore (with offline queue support)
+ * @param {object} note - Note object
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function saveNoteToFirestore(note, userId, db) {
+  if (!userId || !db) return;
+
+  if (!note || typeof note.text !== 'string') {
+    console.error('Invalid note data', note);
+    return;
+  }
+
+  const noteData = {
+    text: note.text,
+    createdAt: note.createdAt || serverTimestamp(),
+  };
+
+  if (note.sourceTaskId) {
+    noteData.sourceTaskId = note.sourceTaskId;
+  }
+
+  try {
+    await offlineQueue.add(
+      'saveNote',
+      async () => {
+        const noteRef = doc(collection(db, 'users', userId, 'notes'), note.id.toString());
+        await setDoc(noteRef, noteData);
+      },
+      {
+        noteId: note.id,
+        userId,
+        noteData,
+      },
+      3 // maxRetries
+    );
+  } catch (error) {
+    console.warn('Firebase note save failed, continuing with local storage:', error);
+    ErrorHandler.handleStorageError(error, {
+      operation: 'saveNoteToFirestore',
+      data: { noteId: note.id },
+      silent: false,
+    });
+  }
+}
+
+/**
+ * Delete a note from Firestore (with offline queue support)
+ * @param {string} noteId - Note ID
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function deleteNoteFromFirestore(noteId, userId, db) {
+  if (!userId || !db) return;
+
+  await offlineQueue.add(
+    'deleteNote',
+    async () => {
+      const noteRef = doc(collection(db, 'users', userId, 'notes'), noteId.toString());
+      await deleteDoc(noteRef);
+    },
+    {
+      noteId,
       userId,
     },
     3 // maxRetries
@@ -422,6 +559,10 @@ export async function importGuestTasksToFirestore(userId, db) {
 
         if (task.category) {
           taskData.category = task.category;
+        }
+
+        if (task.notes) {
+          taskData.notes = task.notes;
         }
 
         batch.set(docRef, taskData);

--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -157,7 +157,8 @@ function createTaskObject(
   recurringConfig = null,
   createdAt = null,
   dueDate = null,
-  category = null
+  category = null,
+  notes = null
 ) {
   const task = {
     id: generateTaskId(), // Stable, collision-free string ID (see generateTaskId)
@@ -176,6 +177,11 @@ function createTaskObject(
   // Add category if provided
   if (category) {
     task.category = category;
+  }
+
+  // Add notes if provided
+  if (notes) {
+    task.notes = notes;
   }
 
   // Add recurring configuration if enabled
@@ -199,6 +205,8 @@ function createTaskObject(
  * @param {object} recurringConfig - Optional recurring configuration
  * @param {function} saveCallback - Callback to save tasks (Firebase or LocalStorage)
  * @param {string} dueDate - Optional due date (ISO string or timestamp)
+ * @param {string} category - Optional category ('private' or 'business')
+ * @param {string} notes - Optional free-text notes
  * @returns {object} The created task
  */
 export function addTaskToSegment(
@@ -207,7 +215,8 @@ export function addTaskToSegment(
   recurringConfig = null,
   saveCallback = null,
   dueDate = null,
-  category = null
+  category = null,
+  notes = null
 ) {
   // Input validation
   if (typeof taskText !== 'string') {
@@ -222,8 +231,22 @@ export function addTaskToSegment(
   if (!Number.isInteger(segmentId) || segmentId < 1 || segmentId > 5) {
     throw new RangeError('Segment ID must be an integer between 1 and 5');
   }
+  if (notes !== null && typeof notes !== 'string') {
+    throw new TypeError('Notes must be a string');
+  }
+  if (notes && notes.length > 500) {
+    throw new Error('Notes must not exceed 500 characters');
+  }
 
-  const task = createTaskObject(taskText, segmentId, recurringConfig, null, dueDate, category);
+  const task = createTaskObject(
+    taskText,
+    segmentId,
+    recurringConfig,
+    null,
+    dueDate,
+    category,
+    notes
+  );
   tasks[segmentId].push(task);
 
   // Call save callback if provided

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -60,6 +60,7 @@ export const translations = {
       q4DetoxConfirm: 'Alle Aufgaben aus "Später!" archivieren?',
       q4DetoxSuccess: 'Q4-Aufgaben archiviert!',
       q4DetoxEmpty: 'Keine Q4-Aufgaben vorhanden',
+      notesBtn: 'Notizen',
     },
     personalize: {
       title: 'Personalisieren',
@@ -77,6 +78,10 @@ export const translations = {
       categoryFilterLabel: 'Kategorie-Filter aktivieren',
       categoryFilterDesc:
         'Über den Umschalter im Kopf zwischen Alle, Privat und Beruflich wechseln. Neue Aufgaben werden der aktiven Kategorie zugeordnet.',
+      notesCollection: 'NOTIZEN',
+      notesCollectionLabel: 'Notizen-Übersicht aktivieren',
+      notesCollectionDesc:
+        'Zeigt einen „Notizen"-Menüpunkt für eine freie Notizliste unabhängig von Aufgaben. Notizen an einzelnen Aufgaben bleiben davon unberührt.',
       reminders: 'ERINNERUNGEN (BETA)',
       remindersLabel: 'Erinnerungen aktivieren',
       remindersDesc: 'Native Benachrichtigungen für Aufgaben mit Fälligkeitsdatum',
@@ -134,6 +139,7 @@ export const translations = {
       categoryNone: 'Keine',
       categoryPrivate: 'Privat',
       categoryBusiness: 'Beruflich',
+      notesPlaceholder: 'Notiz (optional)',
     },
     segmentModal: {
       title: 'Wähle ein Segment',
@@ -143,6 +149,21 @@ export const translations = {
       disableRecurring: 'Wiederholung entfernen (Aufgabe einmalig machen)',
       deleteTask: 'Diese Aufgabe dauerhaft löschen',
       save: 'Speichern',
+    },
+    notes: {
+      title: 'Notizen',
+      inputPlaceholder: 'Neue Notiz…',
+      addButton: 'Hinzufügen',
+      empty: 'Noch keine Notizen',
+      deleteAriaLabel: 'Notiz löschen',
+      sourceBadgePrefix: '→ Aufgabe',
+    },
+    editNotes: {
+      title: 'Notiz bearbeiten',
+      placeholder: 'Notiz (optional)',
+      save: 'Speichern',
+      cancel: 'Abbrechen',
+      ariaLabel: 'Notiz bearbeiten',
     },
     metrics: {
       title: '📊 Produktivitäts-Statistiken',
@@ -275,6 +296,7 @@ export const translations = {
       q4DetoxConfirm: 'Archive all tasks from "Ignore!"?',
       q4DetoxSuccess: 'Q4 tasks archived!',
       q4DetoxEmpty: 'No Q4 tasks to archive',
+      notesBtn: 'Notes',
     },
     personalize: {
       title: 'Personalize',
@@ -292,6 +314,10 @@ export const translations = {
       categoryFilterLabel: 'Enable Category Filter',
       categoryFilterDesc:
         'Switch between All, Private and Business using the header switcher. New tasks are assigned to the active category.',
+      notesCollection: 'NOTES',
+      notesCollectionLabel: 'Enable notes overview',
+      notesCollectionDesc:
+        'Shows a "Notes" menu entry for a free-standing note list independent of tasks. Notes on individual tasks stay available either way.',
       reminders: 'REMINDERS (BETA)',
       remindersLabel: 'Enable Reminders',
       remindersDesc: 'Native notifications for tasks with due dates',
@@ -349,6 +375,7 @@ export const translations = {
       categoryNone: 'None',
       categoryPrivate: 'Private',
       categoryBusiness: 'Business',
+      notesPlaceholder: 'Note (optional)',
     },
     segmentModal: {
       title: 'Choose a segment',
@@ -358,6 +385,21 @@ export const translations = {
       disableRecurring: 'Remove recurring (make one-time task)',
       deleteTask: 'Delete this task permanently',
       save: 'Save',
+    },
+    notes: {
+      title: 'Notes',
+      inputPlaceholder: 'New note…',
+      addButton: 'Add',
+      empty: 'No notes yet',
+      deleteAriaLabel: 'Delete note',
+      sourceBadgePrefix: '→ Task',
+    },
+    editNotes: {
+      title: 'Edit note',
+      placeholder: 'Note (optional)',
+      save: 'Save',
+      cancel: 'Cancel',
+      ariaLabel: 'Edit note',
     },
     metrics: {
       title: '📊 Productivity Statistics',
@@ -756,6 +798,11 @@ export function updateLanguageUI(renderAllTasksCallback) {
     personalizeBtn.textContent = lang.settings.personalizeBtn;
   }
 
+  const notesBtn = document.getElementById('notesBtn');
+  if (notesBtn) {
+    notesBtn.textContent = lang.settings.notesBtn;
+  }
+
   // Update Personalize Modal texts
   const personalizeTitle = document.getElementById('personalizeTitle');
   if (personalizeTitle) {
@@ -785,6 +832,71 @@ export function updateLanguageUI(renderAllTasksCallback) {
   const smartFunctionsDesc = document.getElementById('smartFunctionsDesc');
   if (smartFunctionsDesc) {
     smartFunctionsDesc.textContent = lang.personalize.smartFunctionsDesc;
+  }
+
+  const personalizeNotesCollectionTitle = document.getElementById(
+    'personalizeNotesCollectionTitle'
+  );
+  if (personalizeNotesCollectionTitle) {
+    personalizeNotesCollectionTitle.textContent = lang.personalize.notesCollection;
+  }
+
+  const notesCollectionLabel = document.getElementById('notesCollectionLabel');
+  if (notesCollectionLabel) {
+    notesCollectionLabel.textContent = lang.personalize.notesCollectionLabel;
+  }
+
+  const notesCollectionDesc = document.getElementById('notesCollectionDesc');
+  if (notesCollectionDesc) {
+    notesCollectionDesc.textContent = lang.personalize.notesCollectionDesc;
+  }
+
+  // Update standalone Notes modal texts
+  const notesModalTitle = document.getElementById('notesModalTitle');
+  if (notesModalTitle) {
+    notesModalTitle.textContent = lang.notes.title;
+  }
+
+  const notesAddInput = document.getElementById('notesAddInput');
+  if (notesAddInput) {
+    notesAddInput.placeholder = lang.notes.inputPlaceholder;
+  }
+
+  const notesAddBtn = document.getElementById('notesAddBtn');
+  if (notesAddBtn) {
+    notesAddBtn.textContent = lang.notes.addButton;
+  }
+
+  const notesCancelBtn = document.getElementById('notesCancelBtn');
+  if (notesCancelBtn) {
+    notesCancelBtn.textContent = lang.buttons.close;
+  }
+
+  // Update quick-add notes textarea placeholder
+  const quickAddNotes = document.getElementById('quickAddNotes');
+  if (quickAddNotes) {
+    quickAddNotes.placeholder = lang.quickAddModal.notesPlaceholder;
+  }
+
+  // Update edit-notes modal texts
+  const editNotesTitle = document.getElementById('editNotesTitle');
+  if (editNotesTitle) {
+    editNotesTitle.textContent = lang.editNotes.title;
+  }
+
+  const editNotesTextarea = document.getElementById('editNotesTextarea');
+  if (editNotesTextarea) {
+    editNotesTextarea.placeholder = lang.editNotes.placeholder;
+  }
+
+  const editNotesSaveBtn = document.getElementById('editNotesSaveBtn');
+  if (editNotesSaveBtn) {
+    editNotesSaveBtn.textContent = lang.editNotes.save;
+  }
+
+  const editNotesCancelBtn = document.getElementById('editNotesCancelBtn');
+  if (editNotesCancelBtn) {
+    editNotesCancelBtn.textContent = lang.editNotes.cancel;
   }
 
   // Update Q4-Detox section (title, description, button)

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -104,6 +104,31 @@ export function createTaskElement(task, translations, currentLanguage, callbacks
     textSpan.appendChild(recurringIndicator);
   }
 
+  // Add notes indicator/edit button (always available, not gated by any flag, Issue #371)
+  if (callbacks.onEditNotes) {
+    const notesIndicator = document.createElement('button');
+    notesIndicator.className = 'notes-indicator';
+    notesIndicator.type = 'button';
+    notesIndicator.classList.toggle('has-notes', !!task.notes);
+    const notesLabel = translations[currentLanguage]?.editNotes?.ariaLabel || 'Edit note';
+    notesIndicator.setAttribute('aria-label', notesLabel);
+    notesIndicator.title = task.notes || notesLabel;
+
+    notesIndicator.innerHTML = `
+ <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+ <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+ <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+ </svg>
+ `;
+
+    notesIndicator.addEventListener('click', (e) => {
+      e.stopPropagation();
+      callbacks.onEditNotes(task);
+    });
+
+    textSpan.appendChild(notesIndicator);
+  }
+
   // Add delete button inline after text (only for Done tasks on desktop)
   const isTouchDevice = () => 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   const isDoneTask = task.segment === SEGMENTS.DONE;
@@ -605,6 +630,16 @@ export function openSettingsModal(
       return;
     }
 
+    // Handle Notizen button click (standalone notes collection, Issue #371)
+    if (target.closest('#notesBtn')) {
+      e.preventDefault();
+      closeSettingsModal();
+      if (window.openNotesModalWithData) {
+        window.openNotesModalWithData();
+      }
+      return;
+    }
+
     // Handle close button click
     if (target.closest('#settingsCancelBtn')) {
       closeSettingsModal();
@@ -821,6 +856,12 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     categoryFilterToggle.checked = localStorage.getItem('categoryFilterEnabled') === 'true';
   }
 
+  // Notes collection toggle reflects whether the standalone notes overview is enabled
+  const notesCollectionToggle = document.getElementById('notesCollectionToggle');
+  if (notesCollectionToggle) {
+    notesCollectionToggle.checked = localStorage.getItem('notesCollectionEnabled') === 'true';
+  }
+
   // Update reminders toggle + dropdown state
   const remindersToggle = document.getElementById('remindersToggle');
   const remindersDaysContainer = document.getElementById('remindersDaysContainer');
@@ -910,6 +951,17 @@ export function openPersonalizeModal(currentLanguage = 'en') {
       }
       if (window.renderTasksCallback) {
         window.renderTasksCallback();
+      }
+      return;
+    }
+
+    // Handle notes collection toggle (show/hide the "Notizen" menu entry only)
+    if (target.id === 'notesCollectionToggle') {
+      const isEnabled = target.checked;
+      localStorage.setItem('notesCollectionEnabled', isEnabled.toString());
+
+      if (window.updateNotesMenuVisibility) {
+        window.updateNotesMenuVisibility();
       }
       return;
     }
@@ -1302,6 +1354,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   }
   document.getElementById('quickDueDateToggle')?.classList.remove('icon-toggle-checked');
 
+  // Reset notes field (always visible, not gated by any flag)
+  const quickAddNotes = document.getElementById('quickAddNotes');
+  if (quickAddNotes) {
+    quickAddNotes.value = '';
+  }
+
   // Show category selector only when the category filter feature is enabled,
   // and preselect the active calendar (Privat/Beruflich)
   const categoryConfig = document.getElementById('quickAddCategoryConfig');
@@ -1344,6 +1402,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
 
   // Update input placeholder
   quickAddInput.placeholder = lang.taskInputPlaceholder;
+
+  // Update notes placeholder
+  const quickAddNotesEl = document.getElementById('quickAddNotes');
+  if (quickAddNotesEl && lang.quickAddModal?.notesPlaceholder) {
+    quickAddNotesEl.placeholder = lang.quickAddModal.notesPlaceholder;
+  }
 
   // Update recurring label
   const quickRecurringEnableText = document.getElementById('quickRecurringEnableText');
@@ -1433,9 +1497,13 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
       category = activeBtn?.dataset.category || null;
     }
 
-    // Call callback with due date and category
+    // Get notes if provided (always available, not gated by any flag)
+    const notesInput = document.getElementById('quickAddNotes');
+    const notes = notesInput && notesInput.value.trim() ? notesInput.value.trim() : null;
+
+    // Call callback with due date, category and notes
     if (onAddTask) {
-      onAddTask(text, segmentId, recurringConfig, dueDate, category);
+      onAddTask(text, segmentId, recurringConfig, dueDate, category, notes);
     }
 
     // Close modal
@@ -1604,6 +1672,139 @@ export function openEditRecurringModal(task, onSave, translations, currentLangua
   const newCancelBtn = cancelBtn.cloneNode(true);
   cancelBtn.parentNode.replaceChild(newCancelBtn, cancelBtn);
   newCancelBtn.addEventListener('click', handleCancel);
+}
+
+/**
+ * Open edit-notes modal for an existing task (always available, Issue #371)
+ * @param {object} task - Task to edit
+ * @param {function} onSave - Callback(taskId, newNotes|null) when saved
+ * @param {object} translations - Translations object
+ * @param {string} currentLanguage - Current language
+ */
+export function openEditNotesModal(task, onSave, translations, currentLanguage) {
+  const modal = document.getElementById('editNotesModal');
+  const taskNameElement = document.getElementById('editNotesTaskName');
+  const titleElement = document.getElementById('editNotesTitle');
+  const textarea = document.getElementById('editNotesTextarea');
+  const saveBtn = document.getElementById('editNotesSaveBtn');
+  const cancelBtn = document.getElementById('editNotesCancelBtn');
+
+  if (!modal || !textarea) return;
+
+  const lang = translations[currentLanguage]?.editNotes;
+
+  taskNameElement.textContent = task.text;
+  titleElement.textContent = lang?.title || 'Edit note';
+  textarea.placeholder = lang?.placeholder || '';
+  textarea.value = task.notes || '';
+
+  modal.style.display = 'flex';
+  setTimeout(() => textarea.focus(), 100);
+
+  const handleSave = () => {
+    const value = textarea.value.trim();
+    onSave(task.id, value.length ? value : null);
+    modal.style.display = 'none';
+  };
+
+  const handleCancel = () => {
+    modal.style.display = 'none';
+  };
+
+  // Remove old listeners and add new ones
+  const newSaveBtn = saveBtn.cloneNode(true);
+  saveBtn.parentNode.replaceChild(newSaveBtn, saveBtn);
+  newSaveBtn.textContent = lang?.save || 'Save';
+  newSaveBtn.addEventListener('click', handleSave);
+
+  const newCancelBtn = cancelBtn.cloneNode(true);
+  cancelBtn.parentNode.replaceChild(newCancelBtn, cancelBtn);
+  newCancelBtn.textContent = lang?.cancel || 'Cancel';
+  newCancelBtn.addEventListener('click', handleCancel);
+}
+
+/**
+ * Render the standalone notes list (Issue #371)
+ * @param {Array} notesArray - Flat array of note objects
+ * @param {object} translations - Translations object
+ * @param {string} currentLanguage - Current language
+ * @param {object} callbacks - { onDelete(noteId) }
+ */
+export function renderNotesList(notesArray, translations, currentLanguage, callbacks = {}) {
+  const container = document.getElementById('notesListContainer');
+  if (!container) return;
+
+  const lang = translations[currentLanguage]?.notes;
+  container.innerHTML = '';
+
+  if (!notesArray.length) {
+    const empty = document.createElement('p');
+    empty.className = 'notes-empty-state';
+    empty.textContent = lang?.empty || 'No notes yet';
+    container.appendChild(empty);
+    return;
+  }
+
+  const sorted = [...notesArray].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+  const dateLocale = currentLanguage === 'de' ? 'de-DE' : 'en-US';
+
+  sorted.forEach((note) => {
+    const item = document.createElement('div');
+    item.className = 'note-item';
+    item.dataset.noteId = note.id;
+
+    const content = document.createElement('div');
+    content.className = 'note-item-content';
+
+    const textSpan = document.createElement('span');
+    textSpan.className = 'note-text';
+    textSpan.textContent = note.text;
+    content.appendChild(textSpan);
+
+    const dateSpan = document.createElement('span');
+    dateSpan.className = 'note-date';
+    dateSpan.textContent = new Date(note.createdAt).toLocaleDateString(dateLocale);
+    content.appendChild(dateSpan);
+
+    if (note.sourceTaskId) {
+      const badge = document.createElement('span');
+      badge.className = 'note-source-badge';
+      badge.textContent = `${lang?.sourceBadgePrefix || '→ Task'} ${note.sourceTaskId}`;
+      content.appendChild(badge);
+    }
+
+    item.appendChild(content);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'note-delete-btn';
+    deleteBtn.type = 'button';
+    deleteBtn.setAttribute('aria-label', lang?.deleteAriaLabel || 'Delete note');
+    deleteBtn.textContent = '✕';
+    deleteBtn.addEventListener('click', () => callbacks.onDelete?.(note.id));
+    item.appendChild(deleteBtn);
+
+    container.appendChild(item);
+  });
+}
+
+/**
+ * Open the standalone notes modal (Issue #371)
+ */
+export function openNotesModal() {
+  const modal = document.getElementById('notesModal');
+  if (modal) {
+    modal.style.display = 'flex';
+  }
+}
+
+/**
+ * Close the standalone notes modal
+ */
+export function closeNotesModal() {
+  const modal = document.getElementById('notesModal');
+  if (modal) {
+    modal.style.display = 'none';
+  }
 }
 
 /**

--- a/script.js
+++ b/script.js
@@ -57,6 +57,12 @@ import {
   sameTaskId,
 } from './js/modules/tasks.js';
 import {
+  addNote,
+  deleteNote,
+  getAllNotes,
+  setAllNotes as setAllNotesState,
+} from './js/modules/notes.js';
+import {
   initStorage,
   saveGuestTasks,
   loadGuestTasks,
@@ -64,6 +70,11 @@ import {
   saveTaskToFirestore,
   updateTaskInFirestore,
   deleteTaskFromFirestore,
+  saveGuestNotes,
+  loadGuestNotes,
+  loadUserNotes,
+  saveNoteToFirestore,
+  deleteNoteFromFirestore,
   exportData,
   importData,
   requestPersistentStorage,
@@ -77,6 +88,10 @@ import {
   openSettingsModal,
   openMetricsModal,
   openEditRecurringModal,
+  openEditNotesModal,
+  openNotesModal,
+  closeNotesModal,
+  renderNotesList,
   openTutorialModal,
   shouldShowTutorial,
   showDragHint,
@@ -188,9 +203,29 @@ async function loadAllTasks() {
 }
 
 /**
+ * Load all standalone notes (Guest or Firebase)
+ */
+async function loadAllNotes() {
+  if (currentUser && db && !isGuestMode) {
+    const loadedNotes = await loadUserNotes(currentUser.uid, db);
+    setAllNotesState(loadedNotes);
+  } else {
+    const loadedNotes = await loadGuestNotes();
+    setAllNotesState(loadedNotes);
+  }
+}
+
+/**
  * Add task handler
  */
-function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null, category = null) {
+function handleAddTask(
+  taskText,
+  segment,
+  recurringConfig = null,
+  dueDate = null,
+  category = null,
+  notes = null
+) {
   if (!taskText || taskText.trim() === '') return;
 
   // First real task ends onboarding for good, so demo tasks/explanations
@@ -200,7 +235,7 @@ function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null
   // The Quick Add modal already encodes the category choice (it preselects the
   // active calendar and lets the user override it, including "Keine"), so the
   // explicitly passed category is used as-is and never silently overridden.
-  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate, category);
+  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate, category, notes);
 
   // Save to storage based on mode
   if (currentUser && db && !isGuestMode) {
@@ -472,6 +507,40 @@ function handleEditRecurring(task) {
 }
 
 /**
+ * Handle edit task notes (always available, not gated by any flag, Issue #371)
+ * @param {object} task - Task to edit
+ */
+function handleEditNotes(task) {
+  openEditNotesModal(
+    task,
+    (taskId, newNotes) => {
+      for (const segment in tasks) {
+        const taskIndex = tasks[segment].findIndex((t) => sameTaskId(t.id, taskId));
+        if (taskIndex !== -1) {
+          if (newNotes === null) {
+            delete tasks[segment][taskIndex].notes;
+          } else {
+            tasks[segment][taskIndex].notes = newNotes;
+          }
+
+          const updatedTask = tasks[segment][taskIndex];
+          if (currentUser && db && !isGuestMode) {
+            updateTaskInFirestore(updatedTask, currentUser.uid, db, window.firebase);
+          } else {
+            saveGuestTasks(tasks);
+          }
+
+          renderTasksWithCallbacks();
+          break;
+        }
+      }
+    },
+    translations,
+    getCurrentLanguage()
+  );
+}
+
+/**
  * Render all tasks with all callbacks (Drag & Drop 2.0)
  */
 function renderTasksWithCallbacks() {
@@ -481,6 +550,7 @@ function renderTasksWithCallbacks() {
     onDragEnd: handleMoveTask,
     onSwipeDelete: handleDeleteTask,
     onEditRecurring: handleEditRecurring,
+    onEditNotes: handleEditNotes,
     onReorder: handleReorderTask,
     onDismissDemo: handleDismissDemo,
   };
@@ -589,8 +659,8 @@ function setupEventListeners() {
         // Open Quick Add Modal with Q1 (Do!) pre-selected
         openQuickAddModal(
           1, // Segment 1 (Do!)
-          (text, selectedSegment, recurring, dueDate, category) => {
-            handleAddTask(text, selectedSegment || 1, recurring, dueDate, category);
+          (text, selectedSegment, recurring, dueDate, category, notes) => {
+            handleAddTask(text, selectedSegment || 1, recurring, dueDate, category, notes);
           },
           translations,
           getCurrentLanguage()
@@ -647,8 +717,8 @@ function setupEventListeners() {
       const segment = parseInt(e.target.dataset.segment);
       openQuickAddModal(
         segment,
-        (text, selectedSegment, recurring, dueDate, category) => {
-          handleAddTask(text, selectedSegment || segment, recurring, dueDate, category);
+        (text, selectedSegment, recurring, dueDate, category, notes) => {
+          handleAddTask(text, selectedSegment || segment, recurring, dueDate, category, notes);
         },
         translations,
         getCurrentLanguage()
@@ -724,6 +794,75 @@ function setupEventListeners() {
         renderTasksWithCallbacks();
       });
     });
+  }
+
+  // Notes collection menu entry (Issue #371) - visibility only, task-notes stay
+  // available regardless of this flag.
+  const notesSection = document.getElementById('notesSection');
+  const notesSeparator = document.getElementById('notesSeparator');
+  if (notesSection) {
+    const updateNotesMenuVisibility = () => {
+      const enabled = localStorage.getItem('notesCollectionEnabled') === 'true';
+      notesSection.style.display = enabled ? '' : 'none';
+      if (notesSeparator) notesSeparator.style.display = enabled ? '' : 'none';
+    };
+    updateNotesMenuVisibility();
+    window.updateNotesMenuVisibility = updateNotesMenuVisibility;
+  }
+
+  // Standalone notes modal (Issue #371)
+  const renderNotesListWithCallbacks = () => {
+    renderNotesList(getAllNotes(), translations, getCurrentLanguage(), {
+      onDelete: handleDeleteNote,
+    });
+  };
+  window.openNotesModalWithData = () => {
+    openNotesModal();
+    renderNotesListWithCallbacks();
+  };
+
+  const notesCancelBtn = document.getElementById('notesCancelBtn');
+  if (notesCancelBtn) {
+    notesCancelBtn.addEventListener('click', () => closeNotesModal());
+  }
+
+  const notesAddBtn = document.getElementById('notesAddBtn');
+  const notesAddInput = document.getElementById('notesAddInput');
+  const handleAddNote = () => {
+    const text = notesAddInput.value.trim();
+    if (!text) return;
+
+    const note = addNote(text);
+    if (currentUser && db && !isGuestMode) {
+      saveNoteToFirestore(note, currentUser.uid, db);
+    } else {
+      saveGuestNotes(getAllNotes());
+    }
+
+    notesAddInput.value = '';
+    renderNotesListWithCallbacks();
+  };
+  if (notesAddBtn && notesAddInput) {
+    notesAddBtn.addEventListener('click', handleAddNote);
+    notesAddInput.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleAddNote();
+      }
+    });
+  }
+
+  function handleDeleteNote(noteId) {
+    const removed = deleteNote(noteId);
+    if (!removed) return;
+
+    if (currentUser && db && !isGuestMode) {
+      deleteNoteFromFirestore(removed.id, currentUser.uid, db);
+    } else {
+      saveGuestNotes(getAllNotes());
+    }
+
+    renderNotesListWithCallbacks();
   }
 
   // Settings button (header)
@@ -1227,6 +1366,7 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
     } else {
       await loadAllTasks();
     }
+    await loadAllNotes();
 
     // Wait for DOM to be fully visible after showApp()
     setTimeout(() => {
@@ -1279,6 +1419,7 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
   } else {
     // Tasks already loaded: just re-sync with Firebase in background
     await loadAllTasks();
+    await loadAllNotes();
     renderTasksWithCallbacks();
   }
 };
@@ -1370,6 +1511,7 @@ async function initApp() {
       isGuestMode = true;
       window.showApp();
       await loadAllTasks();
+      await loadAllNotes();
       setupEventListeners();
       if (!keyboardDragManager) {
         keyboardDragManager = new KeyboardDragManager(handleMoveTask);
@@ -1382,6 +1524,7 @@ async function initApp() {
       isGuestMode = false;
       window.showApp();
       await loadAllTasks();
+      await loadAllNotes();
       setupEventListeners();
       if (!keyboardDragManager) {
         keyboardDragManager = new KeyboardDragManager(handleMoveTask);

--- a/tests/unit/notes.test.js
+++ b/tests/unit/notes.test.js
@@ -1,0 +1,120 @@
+/**
+ * Unit Tests for Notes Module (Issue #371)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  generateNoteId,
+  addNote,
+  deleteNote,
+  getAllNotes,
+  setAllNotes,
+} from '../../js/modules/notes.js';
+
+describe('Notes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T10:00:00Z'));
+    setAllNotes([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('generateNoteId', () => {
+    it('should generate unique string IDs', () => {
+      const id1 = generateNoteId();
+      const id2 = generateNoteId();
+      expect(id1).not.toBe(id2);
+      expect(typeof id1).toBe('string');
+    });
+
+    it('should fall back to a timestamp-based ID when crypto.randomUUID is unavailable', () => {
+      vi.stubGlobal('crypto', undefined);
+
+      const id = generateNoteId();
+      expect(id).toMatch(/^note-/);
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe('addNote', () => {
+    it('should create a note with id, text and createdAt', () => {
+      const note = addNote('Buy milk');
+
+      expect(note).toMatchObject({ text: 'Buy milk', createdAt: Date.now() });
+      expect(note.id).toBeTruthy();
+      expect(getAllNotes()).toHaveLength(1);
+      expect(getAllNotes()[0]).toBe(note);
+    });
+
+    it('should trim note text', () => {
+      const note = addNote('  spaced out  ');
+      expect(note.text).toBe('spaced out');
+    });
+
+    it('should invoke the save callback with the created note', () => {
+      const saveCallback = vi.fn();
+      const note = addNote('Call dentist', saveCallback);
+      expect(saveCallback).toHaveBeenCalledWith(note);
+    });
+
+    it('should set sourceTaskId when provided', () => {
+      const note = addNote('From a task', null, 'task-123');
+      expect(note.sourceTaskId).toBe('task-123');
+    });
+
+    it('should not set sourceTaskId when not provided', () => {
+      const note = addNote('Standalone');
+      expect(note).not.toHaveProperty('sourceTaskId');
+    });
+
+    it('should reject non-string text', () => {
+      expect(() => addNote(42)).toThrow(TypeError);
+    });
+
+    it('should reject empty text', () => {
+      expect(() => addNote('   ')).toThrow('Note text cannot be empty');
+    });
+
+    it('should reject text over 500 characters', () => {
+      expect(() => addNote('x'.repeat(501))).toThrow('Note text must not exceed 500 characters');
+    });
+  });
+
+  describe('deleteNote', () => {
+    it('should remove a note by ID and return it', () => {
+      const note = addNote('Delete me');
+      const deleteCallback = vi.fn();
+
+      const removed = deleteNote(note.id, deleteCallback);
+
+      expect(removed).toBe(note);
+      expect(deleteCallback).toHaveBeenCalledWith(note);
+      expect(getAllNotes()).toHaveLength(0);
+    });
+
+    it('should return null and leave the array untouched for an unknown ID', () => {
+      addNote('Keep me');
+      const removed = deleteNote('unknown-id');
+
+      expect(removed).toBeNull();
+      expect(getAllNotes()).toHaveLength(1);
+    });
+  });
+
+  describe('getAllNotes / setAllNotes', () => {
+    it('should round-trip a notes array', () => {
+      const notes = [{ id: '1', text: 'A', createdAt: 1 }];
+      setAllNotes(notes);
+      expect(getAllNotes()).toBe(notes);
+    });
+
+    it('should default to an empty array for non-array input', () => {
+      setAllNotes(null);
+      expect(getAllNotes()).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -10,6 +10,8 @@ import {
   checkPersistentStorage,
   saveGuestTasks,
   loadGuestTasks,
+  saveGuestNotes,
+  loadGuestNotes,
   importData,
 } from '../../js/modules/storage.js';
 import localforage from 'localforage';
@@ -383,6 +385,59 @@ describe('Storage Module', () => {
 
       // Should return empty structure on parse error
       expect(result).toEqual({ 1: [], 2: [], 3: [], 4: [], 5: [] });
+    });
+  });
+
+  describe('saveGuestNotes (Issue #371)', () => {
+    it('should save notes to localforage', async () => {
+      const notes = [{ id: 'n1', text: 'Note 1', createdAt: 1 }];
+
+      const setItemSpy = vi.spyOn(localforage, 'setItem').mockResolvedValue(undefined);
+
+      await saveGuestNotes(notes);
+
+      expect(setItemSpy).toHaveBeenCalledWith('eisenhauer-notes', notes);
+    });
+
+    it('should handle errors gracefully', async () => {
+      vi.spyOn(localforage, 'setItem').mockRejectedValue(new Error('Storage full'));
+
+      await expect(saveGuestNotes([])).resolves.not.toThrow();
+    });
+  });
+
+  describe('loadGuestNotes (Issue #371)', () => {
+    it('should load notes from localforage', async () => {
+      const notes = [{ id: 'n1', text: 'Note 1', createdAt: 1 }];
+      vi.spyOn(localforage, 'getItem').mockResolvedValue(notes);
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual(notes);
+    });
+
+    it('should return an empty array when no data exists', async () => {
+      vi.spyOn(localforage, 'getItem').mockResolvedValue(null);
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array on error', async () => {
+      vi.spyOn(localforage, 'getItem').mockRejectedValue(new Error('DB Error'));
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array for non-array stored data', async () => {
+      vi.spyOn(localforage, 'getItem').mockResolvedValue('not-an-array');
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/tests/unit/tasks.test.js
+++ b/tests/unit/tasks.test.js
@@ -109,6 +109,41 @@ describe('Tasks', () => {
       expect(() => restoreTask({ segment: SEGMENTS.DO })).toThrow('Task ID is required');
     });
 
+    it('should set notes when provided and omit the field otherwise (Issue #371)', () => {
+      const withNotes = addTaskToSegment(
+        'Buy groceries',
+        SEGMENTS.DO,
+        null,
+        null,
+        null,
+        null,
+        'Remember the oat milk'
+      );
+      expect(withNotes.notes).toBe('Remember the oat milk');
+
+      const withoutNotes = addTaskToSegment('No notes here', SEGMENTS.DO);
+      expect(withoutNotes).not.toHaveProperty('notes');
+    });
+
+    it('should validate notes input', () => {
+      expect(() => addTaskToSegment('Task', SEGMENTS.DO, null, null, null, null, 42)).toThrow(
+        TypeError
+      );
+      expect(() =>
+        addTaskToSegment('Task', SEGMENTS.DO, null, null, null, null, 'x'.repeat(501))
+      ).toThrow('Notes must not exceed 500 characters');
+    });
+
+    it('should set or clear notes via updateTask', () => {
+      const task = addTaskToSegment('Task', SEGMENTS.DO);
+
+      updateTask(task.id, SEGMENTS.DO, { notes: 'A quick note' });
+      expect(getTask(task.id, SEGMENTS.DO).notes).toBe('A quick note');
+
+      updateTask(task.id, SEGMENTS.DO, { notes: null });
+      expect(getTask(task.id, SEGMENTS.DO).notes).toBeNull();
+    });
+
     it('should restore and delete tasks with callbacks', () => {
       const task = {
         id: 101,


### PR DESCRIPTION
## Summary

Umsetzung der in Issue #371 skizzierten Notizfunktion, zwei unabhängige Bausteine:

- **Task-Notizen (immer verfügbar, kein Feature-Flag):** optionales Freitextfeld (max. 500 Zeichen) im Quick-Add-Dialog. Bestehende Tasks bekommen einen neuen Notiz-Icon-Button, der ein dediziertes Edit-Modal öffnet (kein Ausbau von `openEditRecurringModal`, da dieses hart an Recurring-Felder gekoppelt ist).
- **Freistehende Notizen-Sammlung (hinter Flag `notesCollectionEnabled`, Default aus):** neues Modul `js/modules/notes.js`, eigener Storage-Pfad (LocalForage-Key `eisenhauer-notes` bzw. Firestore `users/{uid}/notes`), neuer „Notizen"-Menüpunkt/Modal in den Settings, Toggle im Personalisieren-Modal exakt nach dem Muster von „Smarte Funktionen". Der Flag steuert **ausschließlich** die Sichtbarkeit der Sammlungsansicht – Task-Notizen bleiben davon komplett unberührt.

## Änderungen im Detail

- `js/modules/tasks.js`: `createTaskObject`/`addTaskToSegment` um optionalen `notes`-Parameter erweitert (Validierung: String, max. 500 Zeichen)
- `js/modules/notes.js` (neu): CRUD für freistehende Notizen (`addNote`, `deleteNote`, `getAllNotes`, `setAllNotes`, `generateNoteId`)
- `js/modules/config.js`: `STORAGE_KEYS.NOTES`, `STORAGE_KEYS_EXTENDED.NOTES_COLLECTION_ENABLED`
- `js/modules/storage.js`: `saveGuestNotes`/`loadGuestNotes` (LocalForage), `loadUserNotes`/`saveNoteToFirestore`/`deleteNoteFromFirestore` (Firestore); `notes`-Feld in `saveTaskToFirestore`/`updateTaskInFirestore`/`importGuestTasksToFirestore` ergänzt (inkl. `deleteField()` beim Löschen einer Notiz, da `updateTaskInFirestore` mit `merge:true` arbeitet)
- `js/modules/ui.js`: Notiz-Icon-Button in `createTaskElement`, `openEditNotesModal`, `renderNotesList`, `openNotesModal`/`closeNotesModal`, Toggle-Wiring in `openPersonalizeModal`, Notizen-Button-Handling in `openSettingsModal`
- `script.js`: `handleEditNotes`, `loadAllNotes`, Sichtbarkeitssteuerung `updateNotesMenuVisibility` (Muster von `categoryFilterEnabled` übernommen), Add/Delete-Wiring für die Notizen-Sammlung
- `index.html`: Notiz-Textarea im Quick-Add-Modal, „Notizen"-Button in den Settings, Toggle im Personalisieren-Modal, neue Modals `#notesModal` und `#editNotesModal`
- `js/modules/translations.js`: neue i18n-Keys (de/en) für alle neuen UI-Elemente
- Tests: `tests/unit/notes.test.js` (neu), Ergänzungen in `tests/unit/tasks.test.js` und `tests/unit/storage.test.js`

## Test plan

- [x] `npm test` (inkl. `storage.test.js`, lokal mit Firebase-Mocks) – 259 Tests grün
- [x] `npm run lint` – keine neuen Fehler/Warnungen
- [x] `npm run build` (Vite production build) – erfolgreich
- [ ] Manuelle Prüfung im Browser: Guest-Mode Toggle an/aus, Task-Notiz anlegen/bearbeiten, freistehende Notiz anlegen/löschen, de/en

Bezieht sich auf #371.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZct9LVPGA18VPKRTxMSqG)_