### PR TITLE
fix: Edge-to-Edge-Deprecations (#368) + Batch-Writes für saveAllTasks (#337)

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
-        versionCode 27
-        versionName "1.12.2"  // Match PWA version
+        versionCode 28
+        versionName "1.12.3"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -98,7 +98,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.7.0'
 
     // Google Android Browser Helper - TWA Support
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.5.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.7.2'
 
     // Testing
     testImplementation 'junit:junit:4.13.2'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,19 +159,39 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 - CI führt Tests mit `--exclude="tests/unit/storage.test.js"` aus
 - Coverage-Badge in `README.md` verlinkt auf `ci-cd.yml`
 
-## Offene Issues (Backlog-Stand 2026-06-19)
+## Offene Issues (Backlog-Stand 2026-07-29, nach Konsolidierung)
+
+Der Backlog wurde am 2026-07-29 von 19 auf 8 offene Issues konsolidiert (erledigte geschlossen, Duplikate zusammengeführt, Alt-Issues aus 2025 abgeräumt).
 
 | # | Titel | Prio |
 |---|-------|------|
-| #263 | Sentry-Integration (Error Monitoring) | Medium |
-| #265 | CONTRIBUTING.md erstellen | Low |
+| #359 | **Cloud-Backup: Blaze-Tarif nötig** – Architekturentscheidung offen (Firestore-Migration empfohlen). Bündelt auch die allgemeine Spark-/Blaze-Tarif-Frage (vormals #254) | Medium |
+| #352 | **Strategie/Epic: App aufwerten** – Dachplanung (Reflect/Focus/Capture), löst das alte Brainstorm #179 ab. B1–B3 erledigt, A1–A5/B4/B5/C offen | Medium |
+| #367 | Android: R8-Optimierung greift nicht – ProGuard-Regeln entschlacken (Play-Console-Empfehlung) | Medium |
+| #348 | Meta: Rest-Punkte aus Cleanup 2026-07-08 – nur noch lokaler Stash + Dependency-Update-PR | Low |
+| #324 | Sentry-Projekt anlegen + Secrets in GitHub Actions hinterlegen (reiner Ops-Task, Code ist fertig) | Medium |
+| #296 | Cross-App Task Integration (MCP-Server, Firebase REST + Bot-User) | Low |
+| #351 | Import von Apple Reminders (.ics) – gehört unter #352 „Capture" | Low |
 | #266 | JSDoc-Kommentare für alle public functions | Low |
-| #256 | Dependency Updates (firebase, vite, vitest, playwright, eslint) | Low |
-| #245 | Security-Header (CSP) – Phase 2 & 3 ausstehend | Medium |
-| #254 | Firebase Spark-Tarif prüfen | – |
-| #355 | Cloud-Backup schlägt fehl – blockiert durch #359 (siehe unten), kein reiner Code-Fix möglich | Medium |
-| #359 | Cloud-Backup: Firebase Storage erfordert Blaze-Tarif – Architekturentscheidung (Firestore-Migration vs. Feature-Entfernung) offen | Medium |
-| #367 | Playstore fordert Verbesserungen (Sammel-Issue, Detail in #368) | Medium |
+
+> **Wichtig für künftige Backlog-Updates:** Diese Tabelle listete zuvor mehrere längst geschlossene Issues (#263, #265, #256, #245). Vor dem Ergänzen bitte gegen die tatsächlich offenen Issues auf GitHub abgleichen, nicht blind fortschreiben.
+
+### Backlog-Konsolidierung 2026-07-29
+
+Geschlossen und warum – damit nicht später erneut aufgemacht:
+
+| # | Grund |
+|---|-------|
+| #369, #371 | bereits umgesetzt (PR #372 bzw. #373, beide auf `testing`), Issues nur nie geschlossen |
+| #330 | bereits seit PR #360 auf `testing` umgesetzt |
+| #337, #368 | umgesetzt in PR #374 |
+| #179 | abgelöst durch #352 (sagt das im eigenen Body) |
+| #355 | Duplikat von #359 (Symptom vs. Root Cause) |
+| #254 | mit #359 zusammengeführt – gleiche Tarif-Entscheidung |
+| #126 | wontfix, entsprechend der Empfehlung im Issue selbst („Do Nothing") |
+| #55 | wontfix – GitHub-Pages-Pfade sind inhärent case-sensitive, ohne eigene Domain nicht lösbar |
+| #36 | Gamification kollidiert mit der Anti-Bloat-Regel aus #352 |
+| #19 | eigene Domain aktuell nicht geplant |
 
 ### Kürzlich erledigt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,14 @@ Der alte TWA-Splash-Screen (Gradient-Drawable `splash_background.xml` mit Icon i
 
 Beim App-Start wird jetzt ausschließlich der moderne PWA-Splash-Screen angezeigt.
 
+### Edge-to-Edge / Android 15 API-Deprecations (Issue #367, #368)
+
+Play Console meldete die Verwendung nicht mehr unterstützter Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`/`LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`, seit Android 15 deprecated). Die gemeldeten Stacktraces zeigen ausschließlich auf `com.google.androidbrowserhelper`-Klassen (`EdgeToEdgeUtils`, `LauncherActivity`) – die App selbst ruft keine dieser APIs direkt auf (Konfiguration läuft rein über `STATUS_BAR_COLOR`/`NAVIGATION_BAR_COLOR`-Metadaten in `AndroidManifest.xml`, siehe oben).
+
+- `com.google.androidbrowserhelper:androidbrowserhelper` **2.5.0 → 2.7.2** angehoben (`Android/app/build.gradle`) – Version 2.7.1 behebt laut Changelog explizit „Deprecations in launcher activity“, 2.7.0 bringt zusätzlich Edge-to-Edge-Support für den Splash-Screen.
+- Kein eigener App-Code betroffen, daher keine weiteren Änderungen nötig.
+- Nach dem nächsten Play-Store-Upload prüfen, ob die Play-Console-Warnung (#367) verschwindet.
+
 ## Features
 
 ### Sentry Error Monitoring (Issue #263)
@@ -127,6 +135,15 @@ Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` od
 
 **B3 – Micro-Interactions & Motion:** „Erledigt"-Häkchen lösen eine kurze Puls-/Glow-Animation aus (`createTaskElement()` in `ui.js` fügt `task-completing` hinzu, `callbacks.onToggle` wird erst nach ~220ms aufgerufen; bei `prefers-reduced-motion: reduce` sofort ohne Delay). Drag & Drop dimmt jetzt alle Nicht-Ziel-Quadranten (`body.is-dragging .segment:not(.drag-target-segment)`) sowohl im Touch-Pfad (`DragManager#activateDragMode`/`#detectDropTarget`) als auch im Desktop-HTML5-DnD-Pfad (`#handleDragStart`/`#handleDragEnd`/`setupDropZone()` in `drag-manager.js`). Alle neuen Animationen sind im bestehenden `@media (prefers-reduced-motion: reduce)`-Block am Ende von `style.css` deaktiviert.
 
+### Performance: `saveAllTasks()` per Firestore-Batch (Issue #337)
+
+`saveAllTasks()` in `script.js` (genutzt bei Reorder und Import) schrieb für angemeldete Nutzer bisher jede Aufgabe einzeln sequentiell mit `await saveTaskToFirestore(...)` – bei vielen Aufgaben spürbar blockierend.
+
+- Neue Funktion `saveAllTasksToFirestore(tasksBySegment, userId, db)` in `js/modules/storage.js` – schreibt alle Tasks über `writeBatch`, in Chunks à max. 500 Operationen (Firestore-Batch-Limit), analog zum bestehenden Muster in `importGuestTasksToFirestore`.
+- `saveAllTasks()` ruft jetzt `saveAllTasksToFirestore()` statt der Einzel-Write-Schleife auf.
+- **Bestehende Exports bleiben unverändert importierbar:** `saveTaskToFirestore`, `updateTaskInFirestore`, `deleteTaskFromFirestore` und alle anderen Storage-Exports wurden nicht entfernt oder umbenannt – einzelne Task-Operationen (Add/Update/Delete) laufen weiterhin über diese Funktionen inkl. Offline-Queue/Retry-Logik. `saveAllTasksToFirestore` ist ein rein additiver neuer Export.
+- Gast-Modus (`saveGuestTasks`) unverändert.
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):
@@ -154,10 +171,13 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 | #254 | Firebase Spark-Tarif prüfen | – |
 | #355 | Cloud-Backup schlägt fehl – blockiert durch #359 (siehe unten), kein reiner Code-Fix möglich | Medium |
 | #359 | Cloud-Backup: Firebase Storage erfordert Blaze-Tarif – Architekturentscheidung (Firestore-Migration vs. Feature-Entfernung) offen | Medium |
+| #367 | Playstore fordert Verbesserungen (Sammel-Issue, Detail in #368) | Medium |
 
 ### Kürzlich erledigt
 
-- **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes (PR #360)
+- **#368/#367** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben
+- **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben
+- **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes (PR #360). Umsetzung bereits auf `testing`; das GitHub-Issue war nur nicht geschlossen worden.
 - **#352 B1–B3** – Design-Tokens konsolidiert (`--primary-color`/`--primary`/`--primary-rgb`/`--hover-bg` echt definiert), Onboarding mit dismissable Demo-Tasks + Quadranten-Erklärung + freundlichen Empty States (`js/modules/onboarding.js`), „Erledigt"-Micro-Interaction + klareres Drag-Feedback (Segment-Dimming), siehe Abschnitt „Design-Tokens, Onboarding & Micro-Interactions" oben
 - **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt
 - **#179** – Export CSV/Markdown, Smart Suggest (Quadrant-Vorschlag), Matrix-Verteilung in Metriken (PR #332, gemerged 2026-06-19)

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -281,6 +281,68 @@ export async function saveTaskToFirestore(task, userId, db) {
 }
 
 /**
+ * Save all tasks for a user in one or more Firestore batches (chunked at 500 ops/batch,
+ * the Firestore writeBatch limit). Used for bulk operations (reorder, import) where saving
+ * every task sequentially via saveTaskToFirestore would serialize N round-trips and block
+ * the UI. Individual add/update/delete operations keep using saveTaskToFirestore/
+ * updateTaskInFirestore/deleteTaskFromFirestore with their offline-queue retry logic.
+ * @param {object} tasksBySegment - Tasks keyed by segment id, e.g. { 1: [...], 2: [...] }
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function saveAllTasksToFirestore(tasksBySegment, userId, db) {
+  if (!userId || !db) return;
+
+  const allTasks = Object.values(tasksBySegment).flat();
+  if (allTasks.length === 0) return;
+
+  const BATCH_LIMIT = 500;
+
+  for (let i = 0; i < allTasks.length; i += BATCH_LIMIT) {
+    const chunk = allTasks.slice(i, i + BATCH_LIMIT);
+    const batch = writeBatch(db);
+
+    chunk.forEach((task) => {
+      if (!task || typeof task.text !== 'string' || !task.segment) {
+        return;
+      }
+
+      const docRef = doc(collection(db, 'users', userId, 'tasks'), task.id.toString());
+      const taskData = {
+        text: task.text,
+        segment: task.segment,
+        checked: task.checked || false,
+        createdAt: task.createdAt || serverTimestamp(),
+      };
+
+      if (task.completedAt) {
+        taskData.completedAt = task.completedAt;
+      }
+
+      if (task.recurring) {
+        taskData.recurring = task.recurring;
+      }
+
+      if (task.dueDate) {
+        taskData.dueDate = task.dueDate;
+      }
+
+      if (task.category) {
+        taskData.category = task.category;
+      }
+
+      if (task.notes) {
+        taskData.notes = task.notes;
+      }
+
+      batch.set(docRef, taskData);
+    });
+
+    await batch.commit();
+  }
+}
+
+/**
  * Update a task in Firestore (with offline queue support)
  * @param {object} task - Task object
  * @param {string} userId - User ID

--- a/script.js
+++ b/script.js
@@ -68,6 +68,7 @@ import {
   loadGuestTasks,
   loadUserTasks,
   saveTaskToFirestore,
+  saveAllTasksToFirestore,
   updateTaskInFirestore,
   deleteTaskFromFirestore,
   saveGuestNotes,
@@ -167,17 +168,13 @@ window.importGuestTasksToFirestore = importGuestTasksToFirestore;
  * Save all tasks (Guest or Firebase)
  * Note: For Firebase users, this function is not typically called since
  * individual task operations (add/update/delete) save directly to Firestore.
- * This function is mainly used for bulk operations like import.
+ * This function is mainly used for bulk operations like reorder and import,
+ * where it writes all tasks in one or more Firestore batches instead of
+ * sequential per-task writes (see saveAllTasksToFirestore).
  */
 async function saveAllTasks() {
   if (currentUser && db && !isGuestMode) {
-    // For logged-in users, save each task individually to Firestore
-    const { saveTaskToFirestore } = await import('./js/modules/storage.js');
-    for (const segmentId in tasks) {
-      for (const task of tasks[segmentId]) {
-        await saveTaskToFirestore(task, currentUser.uid, db, window.firebase);
-      }
-    }
+    await saveAllTasksToFirestore(tasks, currentUser.uid, db);
   } else {
     await saveGuestTasks(tasks);
   }


### PR DESCRIPTION
# Pull Request

## Beschreibung

Setzt Issue #368 (Android-15-Edge-to-Edge-Deprecations, Detail-Issue von #367) und Issue #337 (Performance von `saveAllTasks()`) um.

**#368/#367 – Edge-to-Edge-Deprecations:**

Google Play meldete die Verwendung nicht mehr unterstützter Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`/`LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`, seit Android 15 deprecated). Die von Play Console gemeldeten Stacktraces zeigen ausschließlich auf `com.google.androidbrowserhelper`-Klassen (`EdgeToEdgeUtils`, `LauncherActivity`) – eigener App-Code ruft diese APIs nirgends direkt auf (Konfiguration läuft komplett über `STATUS_BAR_COLOR`/`NAVIGATION_BAR_COLOR`-Metadaten in `AndroidManifest.xml`).

- `com.google.androidbrowserhelper:androidbrowserhelper` **2.5.0 → 2.7.2** angehoben (`Android/app/build.gradle`). Laut Upstream-Changelog behebt 2.7.1 explizit „Deprecations in launcher activity"; 2.7.0 bringt zusätzlich Edge-to-Edge-Support für den Splash-Screen.
- `versionCode` 27 → 28, `versionName` 1.12.2 → 1.12.3 für den nächsten Play-Store-Upload.
- Kein eigener App-Code betroffen — reines Dependency-Update.

**#337 – `saveAllTasks()` per Firestore-Batch:**

`saveAllTasks()` in `script.js` (genutzt bei Reorder und Import) schrieb für angemeldete Nutzer bisher jede Aufgabe einzeln sequentiell mit `await saveTaskToFirestore(...)` — bei vielen Aufgaben spürbar blockierend.

- Neue Funktion `saveAllTasksToFirestore(tasksBySegment, userId, db)` in `js/modules/storage.js`: schreibt alle Tasks über Firestore `writeBatch`, gechunkt à max. 500 Operationen (Firestore-Batch-Limit) — analog zum bestehenden Muster in `importGuestTasksToFirestore`.
- `saveAllTasks()` ruft jetzt `saveAllTasksToFirestore()` auf statt der Einzel-Write-Schleife.
- **Bestehende Exports bleiben unverändert importierbar:** `saveTaskToFirestore`, `updateTaskInFirestore`, `deleteTaskFromFirestore` und alle anderen Storage-Exports wurden nicht entfernt oder umbenannt. Einzelne Task-Operationen (Add/Update/Delete) laufen weiterhin über diese Funktionen inkl. Offline-Queue/Retry-Logik. `saveAllTasksToFirestore` ist ein rein additiver neuer Export — kein Breaking Change für bestehende Importe.
- Gast-Modus (`saveGuestTasks`) unverändert.

`CLAUDE.md` wurde für beide Themen aktualisiert (neue Abschnitte + „Kürzlich erledigt"). Dabei aufgefallen: Issue **#330** (CI-Concurrency) ist bereits seit PR #360 auf `testing` umgesetzt — das GitHub-Issue war nur nicht geschlossen worden; wird separat geschlossen.

## Art der Änderung

- [x] Bugfix (non-breaking change)
- [x] Neue Funktion (non-breaking change, additiver Export)
- [ ] Breaking Change
- [x] Dokumentation Update (`CLAUDE.md`)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Teilweise — Android-Gradle-Dependency-Update (`Android/`) und reiner PWA-Web-Code (`js/modules/storage.js`, `script.js`), kein React-Native-Code betroffen.

## Testing Checklist

- [x] `npm test -- --exclude="tests/unit/storage.test.js"` — 222/222 Tests grün
- [x] `npm run lint` — keine neuen Fehler (2 bestehende, unveränderte Warnings in `update-version.js`)
- [x] `npm run format:check` — sauber
- [x] `npm run build` — erfolgreich
- [ ] Android-Build (`./gradlew bundleRelease`) — kein Android-SDK in dieser Session verfügbar, im CI zu verifizieren
- [ ] Play-Console-Warnung (#367) verschwindet erst nach dem nächsten Upload — manuell zu bestätigen

## Zusätzliche Notizen

`storage.test.js` deckt Firestore-Funktionen (`saveTaskToFirestore`, `importGuestTasksToFirestore`, jetzt auch `saveAllTasksToFirestore`) bewusst nicht ab, da diese Datei laut `CLAUDE.md` echte Firebase-Credentials benötigt und in CI ausgeschlossen ist — konsistent mit dem bestehenden Testmuster für Firestore-Funktionen.

## Reviewer Checklist

- [x] Code folgt den Projekt-Konventionen
- [x] Keine Web APIs ohne Platform-Check (n/a)
- [x] Keine Hard-coded Values
- [x] Error Handling vorhanden (unverändert für Einzel-Operationen)
- [x] Keine sensiblen Daten im Code
- [x] Commit Messages sind aussagekräftig

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeWQ6SHXyQwp5nB4AwwPQX)_