### PR TITLE
fix(android): blanket androidx-keep aus ProGuard-Regeln entfernen (#367)

### DIFF
--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -2,22 +2,56 @@
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.
 
-# Keep TWA classes
--keep class com.google.androidbrowserhelper.** { *; }
--keep class androidx.browser.** { *; }
-
-# Keep MainActivity
+# ---------------------------------------------------------------------------
+# TWA entry points
+# ---------------------------------------------------------------------------
+# MainActivity extends LauncherActivity and is referenced from AndroidManifest.
+# AGP keeps manifest-declared components automatically; this is explicit because
+# the class name is also part of the published app's public surface.
 -keep class com.sven4321.eisenhauer.MainActivity { *; }
 
-# Keep standard Android classes
+# androidbrowserhelper resolves the TWA launcher and its callbacks partly via
+# reflection, so its classes stay fully kept. This is a small library; unlike
+# the blanket androidx rule below it does not meaningfully block optimization.
+-keep class com.google.androidbrowserhelper.** { *; }
+
+# CustomTabsService/CustomTabsCallback are bound across process boundaries and
+# resolved by name, so androidx.browser stays kept even though the AAR ships
+# consumer rules.
+-keep class androidx.browser.** { *; }
+
+# ---------------------------------------------------------------------------
+# Attributes
+# ---------------------------------------------------------------------------
 -keepattributes *Annotation*
 -keepattributes Signature
 -keepattributes Exception
 
-# AndroidX
--dontwarn androidx.**
--keep class androidx.** { *; }
+# ---------------------------------------------------------------------------
+# AndroidX (Issue #367)
+# ---------------------------------------------------------------------------
+# NOTE: `-keep class androidx.** { *; }` was removed here.
+#
+# That rule protected every class and every member of AndroidX from shrinking,
+# optimization and obfuscation. Since AndroidX makes up the bulk of this TWA's
+# code, it left R8 with almost nothing to remove or inline — which is why the
+# Play Console reported that R8 optimization was not taking effect.
+#
+# It was also redundant: AndroidX AARs ship their own consumer ProGuard rules
+# (`proguard.txt`), which AGP applies automatically. The entry points this app
+# actually needs are covered by the targeted rules above.
+#
+# Do NOT reintroduce a blanket androidx keep to silence a crash. If something
+# breaks at runtime, add a narrow rule for the specific class instead.
 
+# TODO(#367): narrow this once a clean release build shows which warnings are
+# actually emitted. Kept broad for now so the build does not fail on unrelated
+# missing-class warnings from transitive dependencies.
+-dontwarn androidx.**
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
 # Remove logging in release builds
 -assumenosideeffects class android.util.Log {
     public static *** d(...);


### PR DESCRIPTION
# Pull Request

> ⚠️ **Nicht mergen ohne manuellen Gerätetest.** Siehe Abschnitt „Testing Checklist" — falsch entfernte Keep-Regeln brechen erst zur Laufzeit, nicht im Build. Ich kann das hier nicht verifizieren (kein Android-SDK, kein Gerät in dieser Session).

## Beschreibung

Setzt #367 um. Google Play meldete für Release 25 (1.12.1) unter *Technische Qualität*, dass die R8-Optimierung nicht greift.

**Ursache:** `Android/app/proguard-rules.pro` enthielt

```proguard
-keep class androidx.** { *; }
```

Diese Regel schützt **jede Klasse und jedes Member** von AndroidX vor Shrinking, Optimierung und Obfuskation. Da AndroidX den Großteil des Codes dieser TWA ausmacht, blieb für R8 praktisch nichts mehr übrig, das es hätte entfernen oder inlinen können — `minifyEnabled true` lief damit weitgehend ins Leere.

Die Regel war zusätzlich **redundant**: AndroidX-AARs liefern eigene consumer ProGuard-Regeln (`proguard.txt`) mit, die AGP automatisch anwendet. Die Einstiegspunkte, die diese App wirklich braucht, sind durch gezielte Regeln abgedeckt.

## Bewusst konservativ gehalten

Nur die eine, klar redundante Regel wurde entfernt. Absichtlich **nicht** angefasst:

| Regel | Warum sie bleibt |
|---|---|
| `-keep class com.google.androidbrowserhelper.** { *; }` | Löst den TWA-Launcher und Callbacks teils über Reflection auf. Kleine Library — blockiert die Optimierung nicht nennenswert. |
| `-keep class androidx.browser.** { *; }` | `CustomTabsService`/`CustomTabsCallback` werden prozessübergreifend über Namen gebunden. TWA-kritisch. |
| `-dontwarn androidx.**` | Vorerst breit gelassen, damit der Build nicht an unrelated Warnungen aus transitiven Abhängigkeiten scheitert. Als `TODO(#367)` im File vermerkt, sobald ein sauberer Release-Build zeigt, welche Warnungen tatsächlich auftreten. |

Zu `android.enableR8.fullMode` (Checkliste in #367): **nicht gesetzt** — seit AGP 8.0 ist der Default bereits `true`, das Projekt nutzt AGP 8.9.1. Eine explizite Angabe wäre reine Dokumentation und hätte hier keine Wirkung.

Ein ausführlicher Kommentarblock im File erklärt die Entscheidung und warnt davor, bei einem Laufzeit-Crash reflexartig wieder ein blanket-keep einzusetzen statt einer gezielten Regel.

## Art der Änderung

- [x] Bugfix (non-breaking change) — Build-Konfiguration
- [ ] Neue Funktion
- [ ] Breaking Change
- [ ] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Ja — ausschließlich Android-Build-Konfiguration (`Android/app/proguard-rules.pro`). Kein App-, JS- oder PWA-Code betroffen.

## Testing Checklist

- [x] Keine Code-Änderung, nur ProGuard-Konfiguration
- [ ] **Release-Build erfolgreich** (`./gradlew bundleRelease`) — in dieser Session nicht möglich, kein Android-SDK
- [ ] **Manueller Test des Release-Builds auf echtem Gerät** — zwingend vor dem Merge:
  - [ ] App startet, TWA lädt die PWA
  - [ ] Splash-Screen erscheint und verschwindet korrekt
  - [ ] Deep Links (`https://s540d.github.io/Eisenhauer/...`) öffnen die App
  - [ ] Status-/Navigationsleisten-Farben unverändert schwarz
- [ ] AAB-Größe vorher/nachher vergleichen und hier dokumentieren
- [ ] Nach Play-Store-Upload prüfen, ob die R8-Empfehlung verschwindet

## Zusätzliche Notizen

Ein Debug-Build hilft zur Verifikation **nicht** — `minifyEnabled` gilt nur für `release`. Der Test muss gegen einen signierten Release-Build laufen.

Unabhängig von PR #374 (Edge-to-Edge / `androidbrowserhelper`-Bump): keine gemeinsamen Dateien, kein Konflikt zu erwarten.

## Reviewer Checklist

- [x] Code folgt den Projekt-Konventionen
- [x] Keine Web APIs ohne Platform-Check (n/a)
- [x] Keine Hard-coded Values
- [x] Error Handling vorhanden (n/a)
- [x] Keine sensiblen Daten im Code
- [x] Commit Messages sind aussagekräftig

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeWQ6SHXyQwp5nB4AwwPQX)_