### PR TITLE
Release: testing → main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, testing]
   pull_request:
-    branches: [main, testing]
+    branches: [main]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -11,7 +11,7 @@ name: Standards Audit
 
 on:
   pull_request:
-    branches: [main, testing]
+    branches: [main]
   repository_dispatch:
     types: [weekly-self-audit]
   workflow_dispatch: {}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ coverage/
 credentials.json
 *.p12
 *.p8
+aab-archive/

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
-        versionCode 27
-        versionName "1.12.2"  // Match PWA version
+        versionCode 28
+        versionName "1.12.3"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -98,7 +98,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.7.0'
 
     // Google Android Browser Helper - TWA Support
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.5.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.7.2'
 
     // Testing
     testImplementation 'junit:junit:4.13.2'

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sven4321.eisenhauer"
         minSdk 21  // Android 5.0 Lollipop (per project-templates requirement)
         targetSdk 36  // Android 16 – Google Play target API requirement (deadline 2026-08-31)
-        versionCode 26
-        versionName "1.12.1"  // Match PWA version
+        versionCode 27
+        versionName "1.12.2"  // Match PWA version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -2,22 +2,56 @@
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.
 
-# Keep TWA classes
--keep class com.google.androidbrowserhelper.** { *; }
--keep class androidx.browser.** { *; }
-
-# Keep MainActivity
+# ---------------------------------------------------------------------------
+# TWA entry points
+# ---------------------------------------------------------------------------
+# MainActivity extends LauncherActivity and is referenced from AndroidManifest.
+# AGP keeps manifest-declared components automatically; this is explicit because
+# the class name is also part of the published app's public surface.
 -keep class com.sven4321.eisenhauer.MainActivity { *; }
 
-# Keep standard Android classes
+# androidbrowserhelper resolves the TWA launcher and its callbacks partly via
+# reflection, so its classes stay fully kept. This is a small library; unlike
+# the blanket androidx rule below it does not meaningfully block optimization.
+-keep class com.google.androidbrowserhelper.** { *; }
+
+# CustomTabsService/CustomTabsCallback are bound across process boundaries and
+# resolved by name, so androidx.browser stays kept even though the AAR ships
+# consumer rules.
+-keep class androidx.browser.** { *; }
+
+# ---------------------------------------------------------------------------
+# Attributes
+# ---------------------------------------------------------------------------
 -keepattributes *Annotation*
 -keepattributes Signature
 -keepattributes Exception
 
-# AndroidX
--dontwarn androidx.**
--keep class androidx.** { *; }
+# ---------------------------------------------------------------------------
+# AndroidX (Issue #367)
+# ---------------------------------------------------------------------------
+# NOTE: `-keep class androidx.** { *; }` was removed here.
+#
+# That rule protected every class and every member of AndroidX from shrinking,
+# optimization and obfuscation. Since AndroidX makes up the bulk of this TWA's
+# code, it left R8 with almost nothing to remove or inline — which is why the
+# Play Console reported that R8 optimization was not taking effect.
+#
+# It was also redundant: AndroidX AARs ship their own consumer ProGuard rules
+# (`proguard.txt`), which AGP applies automatically. The entry points this app
+# actually needs are covered by the targeted rules above.
+#
+# Do NOT reintroduce a blanket androidx keep to silence a crash. If something
+# breaks at runtime, add a narrow rule for the specific class instead.
 
+# TODO(#367): narrow this once a clean release build shows which warnings are
+# actually emitted. Kept broad for now so the build does not fail on unrelated
+# missing-class warnings from transitive dependencies.
+-dontwarn androidx.**
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
 # Remove logging in release builds
 -assumenosideeffects class android.util.Log {
     public static *** d(...);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ feature/issue-XXX → testing → main (production)
 - **Vor Push:** lokale Tests (`npm test`); kein Merge bei CI-Fail
 - `main` ist protected
 
+### CI-Gate: PRs gegen `testing` laufen praktisch ohne CI (#381)
+
+Seit PR #381 triggern `ci-cd.yml` und `standards-audit.yml` nur noch bei `pull_request` gegen **`main`**. Auf einem PR Feature→`testing` läuft daher nur `mergeability` (plus CodeQL/Security-Scans) – **keine Unit-Tests, kein Lint, kein Build, kein E2E**. Der `push`-Trigger auf `testing` greift erst *nach* dem Merge.
+
+Praktische Konsequenzen:
+
+- **`npm test` und `npm run lint` lokal ausführen ist nicht optional**, sondern der einzige Gate vor `testing`. Grünes CI auf einem Feature-PR sagt nichts über die Tests aus.
+- Das erste echte CI-Gate ist der Release-PR `testing` → `main`. Regressionen fallen dort gebündelt auf, nicht mehr am einzelnen Feature-PR.
+- Beim Bewerten eines gemergten PRs nie aus „CI war grün" auf „Tests liefen" schließen – erst prüfen, *welche* Checks überhaupt getriggert wurden.
+
 ## Android-App (TWA)
 
 - Package: `com.sven4321.eisenhauer`
@@ -211,6 +221,16 @@ Der Backlog wurde am 2026-07-29 von 19 auf 7 offene Issues konsolidiert (erledig
 
 > **Wichtig für künftige Backlog-Updates:** Diese Tabelle listete zuvor mehrere längst geschlossene Issues (#263, #265, #256, #245). Vor dem Ergänzen bitte gegen die tatsächlich offenen Issues auf GitHub abgleichen, nicht blind fortschreiben.
 
+### Offene Punkte aus dem Review von PR #382 (2026-08-08)
+
+Beim Review des Release-PRs `testing` → `main` gefunden. Der blockierende Punkt (geleerte Felder landeten nicht in Firestore) ist mit PR #383 gefixt; die folgenden drei sind **noch nicht als GitHub-Issue erfasst** und daher hier festgehalten, damit sie nicht verloren gehen:
+
+1. **Bulk-Save ohne Offline-Queue** – `saveAllTasksToFirestore()` (`js/modules/storage.js`) committet direkt per `batch.commit()`, ohne `offlineQueue.add(...)`, Retry oder `ErrorHandler`. Der ersetzte Pfad über `saveTaskToFirestore` hatte all das (`maxRetries: 3`). Zusätzlich wird `saveAllTasks()` in `handleReorderTask()` (`script.js`) **weder awaited noch gecatcht** – ein fehlgeschlagener Bulk-Write ist damit komplett still, die UI zeigt die neue Reihenfolge trotzdem an. Der Performance-Gewinn aus #337 ist richtig, die Robustheit sollte nachgezogen werden.
+2. **Freistehende Notizen: kein Gast→Login-Pfad, nicht im Backup** – `loadAllNotes()` lädt bei angemeldeten Nutzern nur aus Firestore; ein Gegenstück zu `importGuestTasksToFirestore()` fehlt, sodass als Gast angelegte Notizen nach dem Anmelden unsichtbar sind (nicht zerstört – sie liegen weiter unter `eisenhauer-notes` in IndexedDB). Außerdem exportiert `exportData()` nur `tasks`, freistehende Notizen fehlen also im JSON-Backup. Task-Notizen sind als Task-Feld korrekt mit drin.
+3. **Kein Click-Suppress nach Long-Press** – `DragManager#handleTouchEnd()` wertet das Event nicht aus, und `preventDefault()` wird nur in `#handleTouchMove` gerufen. Long-Press ohne Bewegung → `#activateDragMode()` → Finger heben → der synthetische `click` erreicht den neuen Handler auf `.task-content` (`ui.js`) und öffnet ungewollt den Edit-Dialog. Bei echten Drags/Swipes mit Bewegung greift das `preventDefault()`.
+
+**Nebenbefund Versionsdrift:** `Android/app/build.gradle` steht auf `versionName "1.12.3"` / `versionCode 28` (Kommentar `// Match PWA version`), `package.json` auf `1.12.2`, `manifest.json` auf `1.12.1`. Der CI-Job „🔧 Version Checks" gibt die Werte nur aus und vergleicht sie **nicht** – er fängt solche Drifts also nicht ab.
+
 ### Backlog-Konsolidierung 2026-07-29
 
 Geschlossen und warum – damit nicht später erneut aufgemacht:
@@ -230,6 +250,7 @@ Geschlossen und warum – damit nicht später erneut aufgemacht:
 
 ### Kürzlich erledigt
 
+- **PR #383** – `updateTaskInFirestore()` löscht geleerte optionale Felder jetzt explizit per `deleteField()` (`completedAt`, `recurring`, `dueDate`, `category`; `notes` war seit PR #373 schon korrekt). Vorher blieb ein im Edit-Dialog geleertes Feld wegen `merge: true` in Firestore stehen und tauchte nach dem Reload wieder auf; `completedAt` verfälschte zusätzlich die Metriken. Nur der Firebase-Modus war betroffen. Gefunden beim Review von PR #382, siehe Abschnitt „Optionale Task-Felder löschen" oben
 - **PR #378** – Bestehende Aufgaben lassen sich per Klick auf den Task-Text im wiederverwendeten Quick-Add-Modal bearbeiten (Prefill + `updateTask()` statt neuer Aufgabe); siehe Abschnitt „Bestehende Aufgaben bearbeiten" oben
 - **#368** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben (PR #374, gemerged)
 - **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben (PR #374, gemerged)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,20 @@ Klick auf den Task-Text öffnet das bestehende Quick-Add-Modal (`openQuickAddMod
 - **Kein Segment-Wechsel im Edit-Modus** – das Modal hat keinen Segment-Picker, Editieren ändert nur Text/Fälligkeit/Wiederholung/Kategorie/Notiz im selben Quadranten.
 - i18n: neue Keys `buttons.save` und `quickAddModal.editTitle` in `translations.js` (de/en).
 
+### Optionale Task-Felder löschen: `deleteField()` statt Feld weglassen
+
+`updateTaskInFirestore()` in `js/modules/storage.js` schreibt mit `setDoc(..., { merge: true })`. Ein **weggelassenes** Feld bedeutet dort „alten Wert behalten" – nicht „Feld löschen". Optionale Felder, die der Nutzer leeren kann, dürfen deshalb nie über ein `if (task.x) { updateData.x = task.x; }` geschrieben werden, sondern müssen den leeren Fall explizit als `deleteField()` senden:
+
+```js
+updateData.dueDate = task.dueDate ? task.dueDate : deleteField();
+```
+
+Betroffen sind `completedAt`, `recurring`, `dueDate`, `category` und `notes`. Vorher war nur `notes` so umgesetzt (PR #373); die übrigen vier hatten den Bug, was durch den Edit-Dialog aus PR #378 sichtbar wurde: Fälligkeit/Kategorie im Dialog leeren → lokal korrekt weg → nach dem Reload wieder da. `completedAt` traf es beim Abwählen einer erledigten Aufgabe (`task.completedAt = null` in `tasks.js`), was die Metriken verfälscht.
+
+- **Nur der Firebase-Modus war betroffen** – `saveGuestTasks()` serialisiert das Task-Objekt komplett und kennt das Problem nicht.
+- Regression-Tests in `tests/unit/storage.test.js` (`describe('updateTaskInFirestore clearable fields')`) mit gemocktem `firebase/firestore`. **Achtung:** Diese Suite ist in der CI per `--exclude` ausgeschlossen, die Tests laufen also nur lokal über `npm test`.
+- Beim Ergänzen weiterer optionaler Task-Felder: immer dem `deleteField()`-Muster folgen.
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,23 @@ Der alte TWA-Splash-Screen (Gradient-Drawable `splash_background.xml` mit Icon i
 
 Beim App-Start wird jetzt ausschließlich der moderne PWA-Splash-Screen angezeigt.
 
-### Edge-to-Edge / Android 15 API-Deprecations (Issue #367, #368)
+### Edge-to-Edge / Android 15 API-Deprecations (Issue #368, PR #374, gemerged)
 
 Play Console meldete die Verwendung nicht mehr unterstützter Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`/`LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`, seit Android 15 deprecated). Die gemeldeten Stacktraces zeigen ausschließlich auf `com.google.androidbrowserhelper`-Klassen (`EdgeToEdgeUtils`, `LauncherActivity`) – die App selbst ruft keine dieser APIs direkt auf (Konfiguration läuft rein über `STATUS_BAR_COLOR`/`NAVIGATION_BAR_COLOR`-Metadaten in `AndroidManifest.xml`, siehe oben).
 
 - `com.google.androidbrowserhelper:androidbrowserhelper` **2.5.0 → 2.7.2** angehoben (`Android/app/build.gradle`) – Version 2.7.1 behebt laut Changelog explizit „Deprecations in launcher activity“, 2.7.0 bringt zusätzlich Edge-to-Edge-Support für den Splash-Screen.
 - Kein eigener App-Code betroffen, daher keine weiteren Änderungen nötig.
-- Nach dem nächsten Play-Store-Upload prüfen, ob die Play-Console-Warnung (#367) verschwindet.
+- Nach dem nächsten Play-Store-Upload prüfen, ob die Play-Console-Warnung verschwindet.
+
+### R8/ProGuard-Optimierung (Issue #367, PR #375, gemerged – Verifikation offen)
+
+Play Console meldete für Release 25 (1.12.1), dass die R8-Optimierung nicht greift. Ursache: `Android/app/proguard-rules.pro` enthielt `-keep class androidx.** { *; }`, was **jede** AndroidX-Klasse pauschal vor Shrinking/Optimierung/Obfuskation schützte – da AndroidX den Großteil des TWA-Codes ausmacht, blieb R8 praktisch nichts zu tun übrig.
+
+- Die Regel wurde entfernt. Bewusst **unverändert** blieben `-keep class com.google.androidbrowserhelper.** { *; }` (Reflection) und `-keep class androidx.browser.** { *; }` (prozessübergreifende Bindung, TWA-kritisch) sowie das breite `-dontwarn androidx.**` (als `TODO(#367)` im File markiert, bis ein sauberer Release-Build zeigt, welche Warnungen real sind).
+- **⚠️ Nicht auf einem echten Gerät getestet.** Kein CI-Check baut einen Android-Release (die Workflows bauen die PWA + Playwright-E2E gegen den Browser) – grünes CI im gemergten PR #375 sagt zu diesem Fix nichts aus. Zu aggressiv entfernte Keep-Regeln brechen erst zur Laufzeit (TWA startet nicht, Splash hängt, Deep Links tot), nicht beim Build.
+- **Vor dem nächsten Play-Store-Upload zwingend:** `cd Android && ./gradlew bundleRelease` bauen und auf einem echten Gerät testen (App-Start, Splash, Deep Links, Status-/Navigationsleisten-Farbe). Ein Debug-Build genügt nicht – `minifyEnabled` gilt nur für `release`.
+- **Bei einem Laufzeit-Crash:** keine pauschale `-keep class androidx.** { *; }`-Regel wiedereinsetzen (macht den Fix wirkungslos), sondern eine gezielte Regel für die konkret betroffene Klasse ergänzen.
+- Issue #367 bleibt bis zum erfolgreichen Gerätetest offen.
 
 ## Features
 
@@ -161,13 +171,13 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 
 ## Offene Issues (Backlog-Stand 2026-07-29, nach Konsolidierung)
 
-Der Backlog wurde am 2026-07-29 von 19 auf 8 offene Issues konsolidiert (erledigte geschlossen, Duplikate zusammengeführt, Alt-Issues aus 2025 abgeräumt).
+Der Backlog wurde am 2026-07-29 von 19 auf 7 offene Issues konsolidiert (erledigte geschlossen, Duplikate zusammengeführt, Alt-Issues aus 2025 abgeräumt).
 
 | # | Titel | Prio |
 |---|-------|------|
 | #359 | **Cloud-Backup: Blaze-Tarif nötig** – Architekturentscheidung offen (Firestore-Migration empfohlen). Bündelt auch die allgemeine Spark-/Blaze-Tarif-Frage (vormals #254) | Medium |
 | #352 | **Strategie/Epic: App aufwerten** – Dachplanung (Reflect/Focus/Capture), löst das alte Brainstorm #179 ab. B1–B3 erledigt, A1–A5/B4/B5/C offen | Medium |
-| #367 | Android: R8-Optimierung greift nicht – ProGuard-Regeln entschlacken (Play-Console-Empfehlung) | Medium |
+| #367 | Android: R8-Fix gemerged (PR #375), **Gerätetest steht aus** – siehe Abschnitt „R8/ProGuard-Optimierung" oben, nicht vor dem nächsten Play-Store-Upload ohne diesen Test | Medium |
 | #348 | Meta: Rest-Punkte aus Cleanup 2026-07-08 – nur noch lokaler Stash + Dependency-Update-PR | Low |
 | #324 | Sentry-Projekt anlegen + Secrets in GitHub Actions hinterlegen (reiner Ops-Task, Code ist fertig) | Medium |
 | #296 | Cross-App Task Integration (MCP-Server, Firebase REST + Bot-User) | Low |
@@ -195,8 +205,9 @@ Geschlossen und warum – damit nicht später erneut aufgemacht:
 
 ### Kürzlich erledigt
 
-- **#368/#367** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben
-- **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben
+- **#368** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben (PR #374, gemerged)
+- **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben (PR #374, gemerged)
+- **#367 (Code-Teil)** – blanket `-keep class androidx.** { *; }` aus `proguard-rules.pro` entfernt (PR #375, gemerged); Issue bleibt offen bis zum Gerätetest, siehe Abschnitt „R8/ProGuard-Optimierung" oben
 - **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes (PR #360). Umsetzung bereits auf `testing`; das GitHub-Issue war nur nicht geschlossen worden.
 - **#352 B1–B3** – Design-Tokens konsolidiert (`--primary-color`/`--primary`/`--primary-rgb`/`--hover-bg` echt definiert), Onboarding mit dismissable Demo-Tasks + Quadranten-Erklärung + freundlichen Empty States (`js/modules/onboarding.js`), „Erledigt"-Micro-Interaction + klareres Drag-Feedback (Segment-Dimming), siehe Abschnitt „Design-Tokens, Onboarding & Micro-Interactions" oben
 - **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,17 @@ Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` od
 - **Bestehende Exports bleiben unverändert importierbar:** `saveTaskToFirestore`, `updateTaskInFirestore`, `deleteTaskFromFirestore` und alle anderen Storage-Exports wurden nicht entfernt oder umbenannt – einzelne Task-Operationen (Add/Update/Delete) laufen weiterhin über diese Funktionen inkl. Offline-Queue/Retry-Logik. `saveAllTasksToFirestore` ist ein rein additiver neuer Export.
 - Gast-Modus (`saveGuestTasks`) unverändert.
 
+### Bestehende Aufgaben bearbeiten (PR #378)
+
+Klick auf den Task-Text öffnet das bestehende Quick-Add-Modal (`openQuickAddModal()` in `js/modules/ui.js`) wieder – vorausgefüllt statt leer – und speichert Änderungen per `updateTask()` (`js/modules/tasks.js`) statt eine neue Aufgabe anzulegen. Kein separates Edit-Modal.
+
+- `openQuickAddModal(segmentId, onAddTask, translations, currentLanguage, existingTask = null)` – neuer optionaler 5. Parameter `existingTask`. Ist er gesetzt: Text/Fälligkeit/Wiederholung/Kategorie/Notiz werden vorausgefüllt, Titel wird zu `lang.quickAddModal.editTitle` ("Aufgabe bearbeiten"/"Edit Task"), der Submit-Button zu `lang.buttons.save` ("Speichern"/"Save") statt `lang.buttons.ok`.
+- **Callback-Signatur erweitert:** `onAddTask(text, segmentId, recurring, dueDate, category, notes, taskId)` – `taskId` ist der neue, angehängte 7. Parameter (`existingTask?.id ?? null`), analog zu `notes` (Issue #371/PR #372, gemergt kurz vor #378 – deshalb Merge-Konflikt in `ui.js` beim Zusammenführen der beiden Feature-Branches, siehe unten). Bestehende Aufrufer, die `onAddTask` mit der alten (kürzeren) Signatur implementieren, funktionieren unverändert weiter – der zusätzliche Parameter wird einfach ignoriert, wenn nicht referenziert.
+- `createTaskElement()` in `ui.js`: Klick auf `.task-content` (nicht auf Checkbox/Wiederholungs-Icon/Notiz-Icon/Löschen-Button – die stoppen weiterhin `event.propagation`) ruft `callbacks.onEditTask(task)`. Neue CSS-Klasse `.task-content-editable` (`cursor: pointer`) als visueller Hinweis.
+- `script.js`: `handleEditTask(taskText, segment, recurringConfig, dueDate, category, notes, taskId)` ruft `updateTask()` auf und speichert je nach Modus (Firestore/`saveGuestTasks`); `handleOpenEditTask(task)` öffnet das Modal im Edit-Modus; beide über `onEditTask: handleOpenEditTask` in `renderTasksWithCallbacks()` verdrahtet.
+- **Kein Segment-Wechsel im Edit-Modus** – das Modal hat keinen Segment-Picker, Editieren ändert nur Text/Fälligkeit/Wiederholung/Kategorie/Notiz im selben Quadranten.
+- i18n: neue Keys `buttons.save` und `quickAddModal.editTitle` in `translations.js` (de/en).
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):
@@ -205,6 +216,7 @@ Geschlossen und warum – damit nicht später erneut aufgemacht:
 
 ### Kürzlich erledigt
 
+- **PR #378** – Bestehende Aufgaben lassen sich per Klick auf den Task-Text im wiederverwendeten Quick-Add-Modal bearbeiten (Prefill + `updateTask()` statt neuer Aufgabe); siehe Abschnitt „Bestehende Aufgaben bearbeiten" oben
 - **#368** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben (PR #374, gemerged)
 - **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben (PR #374, gemerged)
 - **#367 (Code-Teil)** – blanket `-keep class androidx.** { *; }` aus `proguard-rules.pro` entfernt (PR #375, gemerged); Issue bleibt offen bis zum Gerätetest, siehe Abschnitt „R8/ProGuard-Optimierung" oben

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,14 @@ Der alte TWA-Splash-Screen (Gradient-Drawable `splash_background.xml` mit Icon i
 
 Beim App-Start wird jetzt ausschließlich der moderne PWA-Splash-Screen angezeigt.
 
+### Edge-to-Edge / Android 15 API-Deprecations (Issue #367, #368)
+
+Play Console meldete die Verwendung nicht mehr unterstützter Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`/`LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`, seit Android 15 deprecated). Die gemeldeten Stacktraces zeigen ausschließlich auf `com.google.androidbrowserhelper`-Klassen (`EdgeToEdgeUtils`, `LauncherActivity`) – die App selbst ruft keine dieser APIs direkt auf (Konfiguration läuft rein über `STATUS_BAR_COLOR`/`NAVIGATION_BAR_COLOR`-Metadaten in `AndroidManifest.xml`, siehe oben).
+
+- `com.google.androidbrowserhelper:androidbrowserhelper` **2.5.0 → 2.7.2** angehoben (`Android/app/build.gradle`) – Version 2.7.1 behebt laut Changelog explizit „Deprecations in launcher activity“, 2.7.0 bringt zusätzlich Edge-to-Edge-Support für den Splash-Screen.
+- Kein eigener App-Code betroffen, daher keine weiteren Änderungen nötig.
+- Nach dem nächsten Play-Store-Upload prüfen, ob die Play-Console-Warnung (#367) verschwindet.
+
 ## Features
 
 ### Sentry Error Monitoring (Issue #263)
@@ -127,6 +135,15 @@ Aufgaben haben ein optionales Feld `task.category` mit den Werten `'private'` od
 
 **B3 – Micro-Interactions & Motion:** „Erledigt"-Häkchen lösen eine kurze Puls-/Glow-Animation aus (`createTaskElement()` in `ui.js` fügt `task-completing` hinzu, `callbacks.onToggle` wird erst nach ~220ms aufgerufen; bei `prefers-reduced-motion: reduce` sofort ohne Delay). Drag & Drop dimmt jetzt alle Nicht-Ziel-Quadranten (`body.is-dragging .segment:not(.drag-target-segment)`) sowohl im Touch-Pfad (`DragManager#activateDragMode`/`#detectDropTarget`) als auch im Desktop-HTML5-DnD-Pfad (`#handleDragStart`/`#handleDragEnd`/`setupDropZone()` in `drag-manager.js`). Alle neuen Animationen sind im bestehenden `@media (prefers-reduced-motion: reduce)`-Block am Ende von `style.css` deaktiviert.
 
+### Performance: `saveAllTasks()` per Firestore-Batch (Issue #337)
+
+`saveAllTasks()` in `script.js` (genutzt bei Reorder und Import) schrieb für angemeldete Nutzer bisher jede Aufgabe einzeln sequentiell mit `await saveTaskToFirestore(...)` – bei vielen Aufgaben spürbar blockierend.
+
+- Neue Funktion `saveAllTasksToFirestore(tasksBySegment, userId, db)` in `js/modules/storage.js` – schreibt alle Tasks über `writeBatch`, in Chunks à max. 500 Operationen (Firestore-Batch-Limit), analog zum bestehenden Muster in `importGuestTasksToFirestore`.
+- `saveAllTasks()` ruft jetzt `saveAllTasksToFirestore()` statt der Einzel-Write-Schleife auf.
+- **Bestehende Exports bleiben unverändert importierbar:** `saveTaskToFirestore`, `updateTaskInFirestore`, `deleteTaskFromFirestore` und alle anderen Storage-Exports wurden nicht entfernt oder umbenannt – einzelne Task-Operationen (Add/Update/Delete) laufen weiterhin über diese Funktionen inkl. Offline-Queue/Retry-Logik. `saveAllTasksToFirestore` ist ein rein additiver neuer Export.
+- Gast-Modus (`saveGuestTasks`) unverändert.
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):
@@ -142,22 +159,45 @@ Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credenti
 - CI führt Tests mit `--exclude="tests/unit/storage.test.js"` aus
 - Coverage-Badge in `README.md` verlinkt auf `ci-cd.yml`
 
-## Offene Issues (Backlog-Stand 2026-06-19)
+## Offene Issues (Backlog-Stand 2026-07-29, nach Konsolidierung)
+
+Der Backlog wurde am 2026-07-29 von 19 auf 8 offene Issues konsolidiert (erledigte geschlossen, Duplikate zusammengeführt, Alt-Issues aus 2025 abgeräumt).
 
 | # | Titel | Prio |
 |---|-------|------|
-| #263 | Sentry-Integration (Error Monitoring) | Medium |
-| #265 | CONTRIBUTING.md erstellen | Low |
+| #359 | **Cloud-Backup: Blaze-Tarif nötig** – Architekturentscheidung offen (Firestore-Migration empfohlen). Bündelt auch die allgemeine Spark-/Blaze-Tarif-Frage (vormals #254) | Medium |
+| #352 | **Strategie/Epic: App aufwerten** – Dachplanung (Reflect/Focus/Capture), löst das alte Brainstorm #179 ab. B1–B3 erledigt, A1–A5/B4/B5/C offen | Medium |
+| #367 | Android: R8-Optimierung greift nicht – ProGuard-Regeln entschlacken (Play-Console-Empfehlung) | Medium |
+| #348 | Meta: Rest-Punkte aus Cleanup 2026-07-08 – nur noch lokaler Stash + Dependency-Update-PR | Low |
+| #324 | Sentry-Projekt anlegen + Secrets in GitHub Actions hinterlegen (reiner Ops-Task, Code ist fertig) | Medium |
+| #296 | Cross-App Task Integration (MCP-Server, Firebase REST + Bot-User) | Low |
+| #351 | Import von Apple Reminders (.ics) – gehört unter #352 „Capture" | Low |
 | #266 | JSDoc-Kommentare für alle public functions | Low |
-| #256 | Dependency Updates (firebase, vite, vitest, playwright, eslint) | Low |
-| #245 | Security-Header (CSP) – Phase 2 & 3 ausstehend | Medium |
-| #254 | Firebase Spark-Tarif prüfen | – |
-| #355 | Cloud-Backup schlägt fehl – blockiert durch #359 (siehe unten), kein reiner Code-Fix möglich | Medium |
-| #359 | Cloud-Backup: Firebase Storage erfordert Blaze-Tarif – Architekturentscheidung (Firestore-Migration vs. Feature-Entfernung) offen | Medium |
+
+> **Wichtig für künftige Backlog-Updates:** Diese Tabelle listete zuvor mehrere längst geschlossene Issues (#263, #265, #256, #245). Vor dem Ergänzen bitte gegen die tatsächlich offenen Issues auf GitHub abgleichen, nicht blind fortschreiben.
+
+### Backlog-Konsolidierung 2026-07-29
+
+Geschlossen und warum – damit nicht später erneut aufgemacht:
+
+| # | Grund |
+|---|-------|
+| #369, #371 | bereits umgesetzt (PR #372 bzw. #373, beide auf `testing`), Issues nur nie geschlossen |
+| #330 | bereits seit PR #360 auf `testing` umgesetzt |
+| #337, #368 | umgesetzt in PR #374 |
+| #179 | abgelöst durch #352 (sagt das im eigenen Body) |
+| #355 | Duplikat von #359 (Symptom vs. Root Cause) |
+| #254 | mit #359 zusammengeführt – gleiche Tarif-Entscheidung |
+| #126 | wontfix, entsprechend der Empfehlung im Issue selbst („Do Nothing") |
+| #55 | wontfix – GitHub-Pages-Pfade sind inhärent case-sensitive, ohne eigene Domain nicht lösbar |
+| #36 | Gamification kollidiert mit der Anti-Bloat-Regel aus #352 |
+| #19 | eigene Domain aktuell nicht geplant |
 
 ### Kürzlich erledigt
 
-- **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes (PR #360)
+- **#368/#367** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben
+- **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben
+- **#330** – `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` in `ci-cd.yml`, `pr-review.yml`, `standards-audit.yml`, `mergeability.yml`, `build-android.yml`, `cache-cleanup.yml` ergänzt (Vorlage: `deploy-unified.yml`), verhindert redundante Parallel-Läufe bei schnell aufeinanderfolgenden Pushes (PR #360). Umsetzung bereits auf `testing`; das GitHub-Issue war nur nicht geschlossen worden.
 - **#352 B1–B3** – Design-Tokens konsolidiert (`--primary-color`/`--primary`/`--primary-rgb`/`--hover-bg` echt definiert), Onboarding mit dismissable Demo-Tasks + Quadranten-Erklärung + freundlichen Empty States (`js/modules/onboarding.js`), „Erledigt"-Micro-Interaction + klareres Drag-Feedback (Segment-Dimming), siehe Abschnitt „Design-Tokens, Onboarding & Micro-Interactions" oben
 - **PR #346** – Quick-Add-Modal verschlankt: Icon-Toggles für Wiederholung/Fälligkeit (Stil des Fokus-Modus-Toggles), Cancel-Button entfernt, Add-Button durch OK neben dem Eingabefeld ersetzt
 - **#179** – Export CSV/Markdown, Smart Suggest (Quadrant-Vorschlag), Matrix-Verteilung in Metriken (PR #332, gemerged 2026-06-19)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,7 @@ Der Backlog wurde am 2026-07-29 von 19 auf 7 offene Issues konsolidiert (erledig
 | #359 | **Cloud-Backup: Blaze-Tarif nötig** – Architekturentscheidung offen (Firestore-Migration empfohlen). Bündelt auch die allgemeine Spark-/Blaze-Tarif-Frage (vormals #254) | Medium |
 | #352 | **Strategie/Epic: App aufwerten** – Dachplanung (Reflect/Focus/Capture), löst das alte Brainstorm #179 ab. B1–B3 erledigt, A1–A5/B4/B5/C offen | Medium |
 | #367 | Android: R8-Fix gemerged (PR #375), **Gerätetest steht aus** – siehe Abschnitt „R8/ProGuard-Optimierung" oben, nicht vor dem nächsten Play-Store-Upload ohne diesen Test | Medium |
+| #385 | Robustheits-Lücken aus dem Review von PR #382: Bulk-Save ohne Offline-Queue/Retry, Notizen ohne Gast→Login-Migration + fehlend im Backup, kein Click-Suppress nach Long-Press | Medium |
 | #348 | Meta: Rest-Punkte aus Cleanup 2026-07-08 – nur noch lokaler Stash + Dependency-Update-PR | Low |
 | #324 | Sentry-Projekt anlegen + Secrets in GitHub Actions hinterlegen (reiner Ops-Task, Code ist fertig) | Medium |
 | #296 | Cross-App Task Integration (MCP-Server, Firebase REST + Bot-User) | Low |
@@ -220,16 +221,6 @@ Der Backlog wurde am 2026-07-29 von 19 auf 7 offene Issues konsolidiert (erledig
 | #266 | JSDoc-Kommentare für alle public functions | Low |
 
 > **Wichtig für künftige Backlog-Updates:** Diese Tabelle listete zuvor mehrere längst geschlossene Issues (#263, #265, #256, #245). Vor dem Ergänzen bitte gegen die tatsächlich offenen Issues auf GitHub abgleichen, nicht blind fortschreiben.
-
-### Offene Punkte aus dem Review von PR #382 (2026-08-08)
-
-Beim Review des Release-PRs `testing` → `main` gefunden. Der blockierende Punkt (geleerte Felder landeten nicht in Firestore) ist mit PR #383 gefixt; die folgenden drei sind **noch nicht als GitHub-Issue erfasst** und daher hier festgehalten, damit sie nicht verloren gehen:
-
-1. **Bulk-Save ohne Offline-Queue** – `saveAllTasksToFirestore()` (`js/modules/storage.js`) committet direkt per `batch.commit()`, ohne `offlineQueue.add(...)`, Retry oder `ErrorHandler`. Der ersetzte Pfad über `saveTaskToFirestore` hatte all das (`maxRetries: 3`). Zusätzlich wird `saveAllTasks()` in `handleReorderTask()` (`script.js`) **weder awaited noch gecatcht** – ein fehlgeschlagener Bulk-Write ist damit komplett still, die UI zeigt die neue Reihenfolge trotzdem an. Der Performance-Gewinn aus #337 ist richtig, die Robustheit sollte nachgezogen werden.
-2. **Freistehende Notizen: kein Gast→Login-Pfad, nicht im Backup** – `loadAllNotes()` lädt bei angemeldeten Nutzern nur aus Firestore; ein Gegenstück zu `importGuestTasksToFirestore()` fehlt, sodass als Gast angelegte Notizen nach dem Anmelden unsichtbar sind (nicht zerstört – sie liegen weiter unter `eisenhauer-notes` in IndexedDB). Außerdem exportiert `exportData()` nur `tasks`, freistehende Notizen fehlen also im JSON-Backup. Task-Notizen sind als Task-Feld korrekt mit drin.
-3. **Kein Click-Suppress nach Long-Press** – `DragManager#handleTouchEnd()` wertet das Event nicht aus, und `preventDefault()` wird nur in `#handleTouchMove` gerufen. Long-Press ohne Bewegung → `#activateDragMode()` → Finger heben → der synthetische `click` erreicht den neuen Handler auf `.task-content` (`ui.js`) und öffnet ungewollt den Edit-Dialog. Bei echten Drags/Swipes mit Bewegung greift das `preventDefault()`.
-
-**Nebenbefund Versionsdrift:** `Android/app/build.gradle` steht auf `versionName "1.12.3"` / `versionCode 28` (Kommentar `// Match PWA version`), `package.json` auf `1.12.2`, `manifest.json` auf `1.12.1`. Der CI-Job „🔧 Version Checks" gibt die Werte nur aus und vergleicht sie **nicht** – er fängt solche Drifts also nicht ab.
 
 ### Backlog-Konsolidierung 2026-07-29
 

--- a/index.html
+++ b/index.html
@@ -393,6 +393,17 @@
           </label>
         </div>
 
+        <!-- Optional task notes (always visible, not gated by the notes-collection flag) -->
+        <div class="quick-add-notes-row">
+          <textarea
+            id="quickAddNotes"
+            class="quick-add-notes-input"
+            placeholder="Notiz (optional)"
+            maxlength="500"
+            rows="2"
+          ></textarea>
+        </div>
+
         <!-- Recurring Task Configuration -->
         <div id="quickRecurringOptions" class="recurring-options">
           <div class="recurring-option">
@@ -592,6 +603,13 @@
 
         <div class="settings-separator"></div>
 
+        <!-- Notizen Button (only visible when notesCollectionEnabled, Issue #371) -->
+        <div id="notesSection" class="settings-section" style="display: none">
+          <button id="notesBtn" class="btn">Notizen</button>
+        </div>
+
+        <div id="notesSeparator" class="settings-separator" style="display: none"></div>
+
         <!-- JSON Export & Import -->
         <div class="settings-section">
           <h4 id="dataManagementTitle" class="settings-section-title">DATEN</h4>
@@ -739,6 +757,21 @@
           </label>
           <p class="settings-info" id="smartFunctionsDesc">
             Automatisch Aufgaben als dringend markieren, wenn sie in 3 Tagen fällig sind
+          </p>
+        </div>
+
+        <div class="settings-separator"></div>
+
+        <!-- Notes Collection Settings (Issue #371) -->
+        <div class="settings-section">
+          <h4 class="settings-section-title" id="personalizeNotesCollectionTitle">NOTIZEN</h4>
+          <label class="smart-functions-toggle">
+            <input type="checkbox" id="notesCollectionToggle" />
+            <span id="notesCollectionLabel">Notizen-Übersicht aktivieren</span>
+          </label>
+          <p class="settings-info" id="notesCollectionDesc">
+            Zeigt einen „Notizen"-Menüpunkt für eine freie Notizliste unabhängig von Aufgaben.
+            Notizen an einzelnen Aufgaben bleiben davon unberührt.
           </p>
         </div>
 
@@ -911,6 +944,47 @@
           </div>
         </div>
         <button id="metricsCancelBtn" class="btn cancel-btn">Close</button>
+      </div>
+    </div>
+
+    <!-- Notes Modal (standalone notes collection, Issue #371) -->
+    <div id="notesModal" class="modal">
+      <div class="modal-content notes-modal">
+        <h3 id="notesModalTitle">Notizen</h3>
+
+        <div id="notesListContainer" class="notes-list-container"></div>
+
+        <div class="notes-add-row">
+          <input
+            type="text"
+            id="notesAddInput"
+            placeholder="Neue Notiz…"
+            maxlength="500"
+            autocomplete="off"
+          />
+          <button id="notesAddBtn" class="btn">Hinzufügen</button>
+        </div>
+
+        <button id="notesCancelBtn" class="btn cancel-btn">Close</button>
+      </div>
+    </div>
+
+    <!-- Edit Notes Modal (edit notes on an existing task, Issue #371) -->
+    <div id="editNotesModal" class="modal">
+      <div class="modal-content quick-add-modal">
+        <h3 id="editNotesTitle">Notiz bearbeiten</h3>
+        <p id="editNotesTaskName" class="quick-add-category"></p>
+
+        <textarea
+          id="editNotesTextarea"
+          class="quick-add-notes-input"
+          placeholder="Notiz (optional)"
+          maxlength="500"
+          rows="4"
+        ></textarea>
+
+        <button id="editNotesSaveBtn" class="btn">Save</button>
+        <button id="editNotesCancelBtn" class="btn cancel-btn">Cancel</button>
       </div>
     </div>
 

--- a/js/modules/config.js
+++ b/js/modules/config.js
@@ -21,6 +21,7 @@ export const COLORS = {
 
 export const STORAGE_KEYS = {
   TASKS: 'eisenhauer-tasks',
+  NOTES: 'eisenhauer-notes',
   LANGUAGE: 'language',
   DARK_MODE: 'darkMode',
   DRAG_HINT_SEEN: 'dragHintSeen',
@@ -28,6 +29,7 @@ export const STORAGE_KEYS = {
 
 export const UPDATE_CHECK_INTERVAL = 10000; // 10 seconds
 export const MAX_TASK_LENGTH = 140;
+export const MAX_NOTES_LENGTH = 500;
 
 // Smart Rules Configuration
 export const SMART_RULES = {
@@ -37,4 +39,5 @@ export const SMART_RULES = {
 export const STORAGE_KEYS_EXTENDED = {
   ...STORAGE_KEYS,
   SMART_FUNCTIONS_ENABLED: 'smartFunctionsEnabled',
+  NOTES_COLLECTION_ENABLED: 'notesCollectionEnabled',
 };

--- a/js/modules/notes.js
+++ b/js/modules/notes.js
@@ -1,0 +1,100 @@
+/**
+ * Notes Module
+ * Handles the standalone notes collection (independent of tasks)
+ */
+
+// Notes storage (flat, chronological array)
+export let notes = [];
+
+/**
+ * Generate a stable, collision-free note ID.
+ * Mirrors generateTaskId() in tasks.js for consistent ID semantics.
+ * @returns {string} Unique note ID
+ */
+export function generateNoteId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (older browsers/tests)
+  return `note-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Create a new note object
+ */
+function createNoteObject(text, createdAt = null, sourceTaskId = null) {
+  const note = {
+    id: generateNoteId(),
+    text,
+    createdAt: createdAt || Date.now(),
+  };
+
+  if (sourceTaskId) {
+    note.sourceTaskId = sourceTaskId;
+  }
+
+  return note;
+}
+
+/**
+ * Add a new note to the collection
+ * @param {string} text - Note text
+ * @param {function} saveCallback - Callback to save the note (Firebase or LocalStorage)
+ * @param {string} sourceTaskId - Optional ID of the task this note originated from
+ * @returns {object} The created note
+ */
+export function addNote(text, saveCallback = null, sourceTaskId = null) {
+  if (typeof text !== 'string') {
+    throw new TypeError('Note text must be a string');
+  }
+  if (text.trim().length === 0) {
+    throw new Error('Note text cannot be empty');
+  }
+  if (text.length > 500) {
+    throw new Error('Note text must not exceed 500 characters');
+  }
+
+  const note = createNoteObject(text.trim(), null, sourceTaskId);
+  notes.push(note);
+
+  if (saveCallback) {
+    saveCallback(note);
+  }
+
+  return note;
+}
+
+/**
+ * Delete a note by ID
+ * @param {string} noteId - ID of the note to delete
+ * @param {function} deleteCallback - Callback to persist the deletion
+ * @returns {object|null} The removed note, or null if not found
+ */
+export function deleteNote(noteId, deleteCallback = null) {
+  const index = notes.findIndex((n) => String(n.id) === String(noteId));
+  if (index === -1) return null;
+
+  const [removed] = notes.splice(index, 1);
+
+  if (deleteCallback) {
+    deleteCallback(removed);
+  }
+
+  return removed;
+}
+
+/**
+ * Get all notes
+ * @returns {Array} All notes
+ */
+export function getAllNotes() {
+  return notes;
+}
+
+/**
+ * Replace the entire notes collection (used after loading from storage)
+ * @param {Array} newNotes - Notes to set
+ */
+export function setAllNotes(newNotes) {
+  notes = Array.isArray(newNotes) ? newNotes : [];
+}

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -9,12 +9,14 @@ import { isGuestMode } from './auth.js';
 import { OfflineQueue } from './offline-queue.js';
 import { ErrorHandler } from './error-handler.js';
 import { showError, showInfo, showWarning } from './notifications.js';
+import { STORAGE_KEYS } from './config.js';
 import {
   collection,
   doc,
   getDocs,
   setDoc,
   deleteDoc,
+  deleteField,
   writeBatch,
   serverTimestamp,
 } from 'firebase/firestore';
@@ -247,6 +249,10 @@ export async function saveTaskToFirestore(task, userId, db) {
     taskData.category = task.category;
   }
 
+  if (task.notes) {
+    taskData.notes = task.notes;
+  }
+
   // Add to offline queue with retry logic and error handling
   try {
     await offlineQueue.add(
@@ -308,6 +314,12 @@ export async function updateTaskInFirestore(task, userId, db) {
     updateData.category = task.category;
   }
 
+  // setDoc uses merge:true below, so an omitted field would just keep its old
+  // value in Firestore. Notes are user-clearable (empty the textarea to
+  // remove a note), so an absent/empty value must explicitly delete the
+  // field rather than silently leaving a stale one behind.
+  updateData.notes = task.notes ? task.notes : deleteField();
+
   // Add to offline queue with retry logic
   await offlineQueue.add(
     'updateTask',
@@ -344,6 +356,131 @@ export async function deleteTaskFromFirestore(taskId, userId, db) {
     },
     {
       taskId,
+      userId,
+    },
+    3 // maxRetries
+  );
+}
+
+/**
+ * Save guest notes to LocalForage (IndexedDB)
+ * @param {Array} notes - Flat array of note objects
+ */
+export async function saveGuestNotes(notes) {
+  try {
+    await localforage.setItem(STORAGE_KEYS.NOTES, notes);
+  } catch (_error) {
+    // Guest note save failure is non-fatal; data remains in memory
+  }
+}
+
+/**
+ * Load guest notes from LocalForage
+ * @returns {Promise<Array>} Notes array
+ */
+export async function loadGuestNotes() {
+  try {
+    const notesData = await localforage.getItem(STORAGE_KEYS.NOTES);
+    return Array.isArray(notesData) ? notesData : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+/**
+ * Load user notes from Firestore
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ * @returns {Promise<Array>} Notes array
+ */
+export async function loadUserNotes(userId, db) {
+  if (!userId || !db) return [];
+
+  try {
+    const notesRef = collection(db, 'users', userId, 'notes');
+    const snapshot = await getDocs(notesRef);
+
+    const notes = [];
+    snapshot.forEach((docSnap) => {
+      const note = docSnap.data();
+      note.id = String(docSnap.id);
+      notes.push(note);
+    });
+
+    // Firestore doesn't guarantee order without an explicit orderBy query,
+    // so sort client-side to keep the collection chronological.
+    notes.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+
+    return notes;
+  } catch (_error) {
+    return [];
+  }
+}
+
+/**
+ * Save a single note to Firestore (with offline queue support)
+ * @param {object} note - Note object
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function saveNoteToFirestore(note, userId, db) {
+  if (!userId || !db) return;
+
+  if (!note || typeof note.text !== 'string') {
+    console.error('Invalid note data', note);
+    return;
+  }
+
+  const noteData = {
+    text: note.text,
+    createdAt: note.createdAt || serverTimestamp(),
+  };
+
+  if (note.sourceTaskId) {
+    noteData.sourceTaskId = note.sourceTaskId;
+  }
+
+  try {
+    await offlineQueue.add(
+      'saveNote',
+      async () => {
+        const noteRef = doc(collection(db, 'users', userId, 'notes'), note.id.toString());
+        await setDoc(noteRef, noteData);
+      },
+      {
+        noteId: note.id,
+        userId,
+        noteData,
+      },
+      3 // maxRetries
+    );
+  } catch (error) {
+    console.warn('Firebase note save failed, continuing with local storage:', error);
+    ErrorHandler.handleStorageError(error, {
+      operation: 'saveNoteToFirestore',
+      data: { noteId: note.id },
+      silent: false,
+    });
+  }
+}
+
+/**
+ * Delete a note from Firestore (with offline queue support)
+ * @param {string} noteId - Note ID
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function deleteNoteFromFirestore(noteId, userId, db) {
+  if (!userId || !db) return;
+
+  await offlineQueue.add(
+    'deleteNote',
+    async () => {
+      const noteRef = doc(collection(db, 'users', userId, 'notes'), noteId.toString());
+      await deleteDoc(noteRef);
+    },
+    {
+      noteId,
       userId,
     },
     3 // maxRetries
@@ -422,6 +559,10 @@ export async function importGuestTasksToFirestore(userId, db) {
 
         if (task.category) {
           taskData.category = task.category;
+        }
+
+        if (task.notes) {
+          taskData.notes = task.notes;
         }
 
         batch.set(docRef, taskData);

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -281,6 +281,68 @@ export async function saveTaskToFirestore(task, userId, db) {
 }
 
 /**
+ * Save all tasks for a user in one or more Firestore batches (chunked at 500 ops/batch,
+ * the Firestore writeBatch limit). Used for bulk operations (reorder, import) where saving
+ * every task sequentially via saveTaskToFirestore would serialize N round-trips and block
+ * the UI. Individual add/update/delete operations keep using saveTaskToFirestore/
+ * updateTaskInFirestore/deleteTaskFromFirestore with their offline-queue retry logic.
+ * @param {object} tasksBySegment - Tasks keyed by segment id, e.g. { 1: [...], 2: [...] }
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ */
+export async function saveAllTasksToFirestore(tasksBySegment, userId, db) {
+  if (!userId || !db) return;
+
+  const allTasks = Object.values(tasksBySegment).flat();
+  if (allTasks.length === 0) return;
+
+  const BATCH_LIMIT = 500;
+
+  for (let i = 0; i < allTasks.length; i += BATCH_LIMIT) {
+    const chunk = allTasks.slice(i, i + BATCH_LIMIT);
+    const batch = writeBatch(db);
+
+    chunk.forEach((task) => {
+      if (!task || typeof task.text !== 'string' || !task.segment) {
+        return;
+      }
+
+      const docRef = doc(collection(db, 'users', userId, 'tasks'), task.id.toString());
+      const taskData = {
+        text: task.text,
+        segment: task.segment,
+        checked: task.checked || false,
+        createdAt: task.createdAt || serverTimestamp(),
+      };
+
+      if (task.completedAt) {
+        taskData.completedAt = task.completedAt;
+      }
+
+      if (task.recurring) {
+        taskData.recurring = task.recurring;
+      }
+
+      if (task.dueDate) {
+        taskData.dueDate = task.dueDate;
+      }
+
+      if (task.category) {
+        taskData.category = task.category;
+      }
+
+      if (task.notes) {
+        taskData.notes = task.notes;
+      }
+
+      batch.set(docRef, taskData);
+    });
+
+    await batch.commit();
+  }
+}
+
+/**
  * Update a task in Firestore (with offline queue support)
  * @param {object} task - Task object
  * @param {string} userId - User ID

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -360,26 +360,17 @@ export async function updateTaskInFirestore(task, userId, db) {
     createdAt: task.createdAt || serverTimestamp(),
   };
 
-  if (task.completedAt) {
-    updateData.completedAt = task.completedAt;
-  }
-
-  if (task.recurring) {
-    updateData.recurring = task.recurring;
-  }
-
-  if (task.dueDate) {
-    updateData.dueDate = task.dueDate;
-  }
-
-  if (task.category) {
-    updateData.category = task.category;
-  }
-
   // setDoc uses merge:true below, so an omitted field would just keep its old
-  // value in Firestore. Notes are user-clearable (empty the textarea to
-  // remove a note), so an absent/empty value must explicitly delete the
-  // field rather than silently leaving a stale one behind.
+  // value in Firestore. Every optional field here is user-clearable — the edit
+  // dialog can drop the due date, the category ("Keine"), the notes and the
+  // recurring config, and un-checking a Done task resets completedAt — so an
+  // absent/empty value must explicitly delete the field rather than silently
+  // leaving a stale one behind. Without this the cleared value reappears on
+  // the next load (Issue: clearing fields did not persist for signed-in users).
+  updateData.completedAt = task.completedAt ? task.completedAt : deleteField();
+  updateData.recurring = task.recurring ? task.recurring : deleteField();
+  updateData.dueDate = task.dueDate ? task.dueDate : deleteField();
+  updateData.category = task.category ? task.category : deleteField();
   updateData.notes = task.notes ? task.notes : deleteField();
 
   // Add to offline queue with retry logic

--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -157,7 +157,8 @@ function createTaskObject(
   recurringConfig = null,
   createdAt = null,
   dueDate = null,
-  category = null
+  category = null,
+  notes = null
 ) {
   const task = {
     id: generateTaskId(), // Stable, collision-free string ID (see generateTaskId)
@@ -176,6 +177,11 @@ function createTaskObject(
   // Add category if provided
   if (category) {
     task.category = category;
+  }
+
+  // Add notes if provided
+  if (notes) {
+    task.notes = notes;
   }
 
   // Add recurring configuration if enabled
@@ -199,6 +205,8 @@ function createTaskObject(
  * @param {object} recurringConfig - Optional recurring configuration
  * @param {function} saveCallback - Callback to save tasks (Firebase or LocalStorage)
  * @param {string} dueDate - Optional due date (ISO string or timestamp)
+ * @param {string} category - Optional category ('private' or 'business')
+ * @param {string} notes - Optional free-text notes
  * @returns {object} The created task
  */
 export function addTaskToSegment(
@@ -207,7 +215,8 @@ export function addTaskToSegment(
   recurringConfig = null,
   saveCallback = null,
   dueDate = null,
-  category = null
+  category = null,
+  notes = null
 ) {
   // Input validation
   if (typeof taskText !== 'string') {
@@ -222,8 +231,22 @@ export function addTaskToSegment(
   if (!Number.isInteger(segmentId) || segmentId < 1 || segmentId > 5) {
     throw new RangeError('Segment ID must be an integer between 1 and 5');
   }
+  if (notes !== null && typeof notes !== 'string') {
+    throw new TypeError('Notes must be a string');
+  }
+  if (notes && notes.length > 500) {
+    throw new Error('Notes must not exceed 500 characters');
+  }
 
-  const task = createTaskObject(taskText, segmentId, recurringConfig, null, dueDate, category);
+  const task = createTaskObject(
+    taskText,
+    segmentId,
+    recurringConfig,
+    null,
+    dueDate,
+    category,
+    notes
+  );
   tasks[segmentId].push(task);
 
   // Call save callback if provided

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -60,6 +60,7 @@ export const translations = {
       q4DetoxConfirm: 'Alle Aufgaben aus "Später!" archivieren?',
       q4DetoxSuccess: 'Q4-Aufgaben archiviert!',
       q4DetoxEmpty: 'Keine Q4-Aufgaben vorhanden',
+      notesBtn: 'Notizen',
     },
     personalize: {
       title: 'Personalisieren',
@@ -77,6 +78,10 @@ export const translations = {
       categoryFilterLabel: 'Kategorie-Filter aktivieren',
       categoryFilterDesc:
         'Über den Umschalter im Kopf zwischen Alle, Privat und Beruflich wechseln. Neue Aufgaben werden der aktiven Kategorie zugeordnet.',
+      notesCollection: 'NOTIZEN',
+      notesCollectionLabel: 'Notizen-Übersicht aktivieren',
+      notesCollectionDesc:
+        'Zeigt einen „Notizen"-Menüpunkt für eine freie Notizliste unabhängig von Aufgaben. Notizen an einzelnen Aufgaben bleiben davon unberührt.',
       reminders: 'ERINNERUNGEN (BETA)',
       remindersLabel: 'Erinnerungen aktivieren',
       remindersDesc: 'Native Benachrichtigungen für Aufgaben mit Fälligkeitsdatum',
@@ -134,6 +139,7 @@ export const translations = {
       categoryNone: 'Keine',
       categoryPrivate: 'Privat',
       categoryBusiness: 'Beruflich',
+      notesPlaceholder: 'Notiz (optional)',
     },
     segmentModal: {
       title: 'Wähle ein Segment',
@@ -143,6 +149,21 @@ export const translations = {
       disableRecurring: 'Wiederholung entfernen (Aufgabe einmalig machen)',
       deleteTask: 'Diese Aufgabe dauerhaft löschen',
       save: 'Speichern',
+    },
+    notes: {
+      title: 'Notizen',
+      inputPlaceholder: 'Neue Notiz…',
+      addButton: 'Hinzufügen',
+      empty: 'Noch keine Notizen',
+      deleteAriaLabel: 'Notiz löschen',
+      sourceBadgePrefix: '→ Aufgabe',
+    },
+    editNotes: {
+      title: 'Notiz bearbeiten',
+      placeholder: 'Notiz (optional)',
+      save: 'Speichern',
+      cancel: 'Abbrechen',
+      ariaLabel: 'Notiz bearbeiten',
     },
     metrics: {
       title: '📊 Produktivitäts-Statistiken',
@@ -275,6 +296,7 @@ export const translations = {
       q4DetoxConfirm: 'Archive all tasks from "Ignore!"?',
       q4DetoxSuccess: 'Q4 tasks archived!',
       q4DetoxEmpty: 'No Q4 tasks to archive',
+      notesBtn: 'Notes',
     },
     personalize: {
       title: 'Personalize',
@@ -292,6 +314,10 @@ export const translations = {
       categoryFilterLabel: 'Enable Category Filter',
       categoryFilterDesc:
         'Switch between All, Private and Business using the header switcher. New tasks are assigned to the active category.',
+      notesCollection: 'NOTES',
+      notesCollectionLabel: 'Enable notes overview',
+      notesCollectionDesc:
+        'Shows a "Notes" menu entry for a free-standing note list independent of tasks. Notes on individual tasks stay available either way.',
       reminders: 'REMINDERS (BETA)',
       remindersLabel: 'Enable Reminders',
       remindersDesc: 'Native notifications for tasks with due dates',
@@ -349,6 +375,7 @@ export const translations = {
       categoryNone: 'None',
       categoryPrivate: 'Private',
       categoryBusiness: 'Business',
+      notesPlaceholder: 'Note (optional)',
     },
     segmentModal: {
       title: 'Choose a segment',
@@ -358,6 +385,21 @@ export const translations = {
       disableRecurring: 'Remove recurring (make one-time task)',
       deleteTask: 'Delete this task permanently',
       save: 'Save',
+    },
+    notes: {
+      title: 'Notes',
+      inputPlaceholder: 'New note…',
+      addButton: 'Add',
+      empty: 'No notes yet',
+      deleteAriaLabel: 'Delete note',
+      sourceBadgePrefix: '→ Task',
+    },
+    editNotes: {
+      title: 'Edit note',
+      placeholder: 'Note (optional)',
+      save: 'Save',
+      cancel: 'Cancel',
+      ariaLabel: 'Edit note',
     },
     metrics: {
       title: '📊 Productivity Statistics',
@@ -756,6 +798,11 @@ export function updateLanguageUI(renderAllTasksCallback) {
     personalizeBtn.textContent = lang.settings.personalizeBtn;
   }
 
+  const notesBtn = document.getElementById('notesBtn');
+  if (notesBtn) {
+    notesBtn.textContent = lang.settings.notesBtn;
+  }
+
   // Update Personalize Modal texts
   const personalizeTitle = document.getElementById('personalizeTitle');
   if (personalizeTitle) {
@@ -785,6 +832,71 @@ export function updateLanguageUI(renderAllTasksCallback) {
   const smartFunctionsDesc = document.getElementById('smartFunctionsDesc');
   if (smartFunctionsDesc) {
     smartFunctionsDesc.textContent = lang.personalize.smartFunctionsDesc;
+  }
+
+  const personalizeNotesCollectionTitle = document.getElementById(
+    'personalizeNotesCollectionTitle'
+  );
+  if (personalizeNotesCollectionTitle) {
+    personalizeNotesCollectionTitle.textContent = lang.personalize.notesCollection;
+  }
+
+  const notesCollectionLabel = document.getElementById('notesCollectionLabel');
+  if (notesCollectionLabel) {
+    notesCollectionLabel.textContent = lang.personalize.notesCollectionLabel;
+  }
+
+  const notesCollectionDesc = document.getElementById('notesCollectionDesc');
+  if (notesCollectionDesc) {
+    notesCollectionDesc.textContent = lang.personalize.notesCollectionDesc;
+  }
+
+  // Update standalone Notes modal texts
+  const notesModalTitle = document.getElementById('notesModalTitle');
+  if (notesModalTitle) {
+    notesModalTitle.textContent = lang.notes.title;
+  }
+
+  const notesAddInput = document.getElementById('notesAddInput');
+  if (notesAddInput) {
+    notesAddInput.placeholder = lang.notes.inputPlaceholder;
+  }
+
+  const notesAddBtn = document.getElementById('notesAddBtn');
+  if (notesAddBtn) {
+    notesAddBtn.textContent = lang.notes.addButton;
+  }
+
+  const notesCancelBtn = document.getElementById('notesCancelBtn');
+  if (notesCancelBtn) {
+    notesCancelBtn.textContent = lang.buttons.close;
+  }
+
+  // Update quick-add notes textarea placeholder
+  const quickAddNotes = document.getElementById('quickAddNotes');
+  if (quickAddNotes) {
+    quickAddNotes.placeholder = lang.quickAddModal.notesPlaceholder;
+  }
+
+  // Update edit-notes modal texts
+  const editNotesTitle = document.getElementById('editNotesTitle');
+  if (editNotesTitle) {
+    editNotesTitle.textContent = lang.editNotes.title;
+  }
+
+  const editNotesTextarea = document.getElementById('editNotesTextarea');
+  if (editNotesTextarea) {
+    editNotesTextarea.placeholder = lang.editNotes.placeholder;
+  }
+
+  const editNotesSaveBtn = document.getElementById('editNotesSaveBtn');
+  if (editNotesSaveBtn) {
+    editNotesSaveBtn.textContent = lang.editNotes.save;
+  }
+
+  const editNotesCancelBtn = document.getElementById('editNotesCancelBtn');
+  if (editNotesCancelBtn) {
+    editNotesCancelBtn.textContent = lang.editNotes.cancel;
   }
 
   // Update Q4-Detox section (title, description, button)

--- a/js/modules/translations.js
+++ b/js/modules/translations.js
@@ -35,6 +35,7 @@ export const translations = {
       cancel: 'Abbrechen',
       close: 'Schließen',
       ok: 'OK',
+      save: 'Speichern',
     },
     settings: {
       title: 'Einstellungen',
@@ -132,6 +133,7 @@ export const translations = {
     },
     quickAddModal: {
       title: 'Neue Aufgabe',
+      editTitle: 'Aufgabe bearbeiten',
       inputPlaceholder: 'Was möchtest du tun?',
       monthDayLabel: 'Tag (1-31)',
       dueDate: 'Fällig am',
@@ -271,6 +273,7 @@ export const translations = {
       cancel: 'Cancel',
       close: 'Close',
       ok: 'OK',
+      save: 'Save',
     },
     settings: {
       title: 'Settings',
@@ -368,6 +371,7 @@ export const translations = {
     },
     quickAddModal: {
       title: 'New Task',
+      editTitle: 'Edit Task',
       inputPlaceholder: 'What do you want to do?',
       monthDayLabel: 'Day (1-31)',
       dueDate: 'Due Date',

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -104,6 +104,31 @@ export function createTaskElement(task, translations, currentLanguage, callbacks
     textSpan.appendChild(recurringIndicator);
   }
 
+  // Add notes indicator/edit button (always available, not gated by any flag, Issue #371)
+  if (callbacks.onEditNotes) {
+    const notesIndicator = document.createElement('button');
+    notesIndicator.className = 'notes-indicator';
+    notesIndicator.type = 'button';
+    notesIndicator.classList.toggle('has-notes', !!task.notes);
+    const notesLabel = translations[currentLanguage]?.editNotes?.ariaLabel || 'Edit note';
+    notesIndicator.setAttribute('aria-label', notesLabel);
+    notesIndicator.title = task.notes || notesLabel;
+
+    notesIndicator.innerHTML = `
+ <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+ <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+ <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+ </svg>
+ `;
+
+    notesIndicator.addEventListener('click', (e) => {
+      e.stopPropagation();
+      callbacks.onEditNotes(task);
+    });
+
+    textSpan.appendChild(notesIndicator);
+  }
+
   // Add delete button inline after text (only for Done tasks on desktop)
   const isTouchDevice = () => 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   const isDoneTask = task.segment === SEGMENTS.DONE;
@@ -605,6 +630,16 @@ export function openSettingsModal(
       return;
     }
 
+    // Handle Notizen button click (standalone notes collection, Issue #371)
+    if (target.closest('#notesBtn')) {
+      e.preventDefault();
+      closeSettingsModal();
+      if (window.openNotesModalWithData) {
+        window.openNotesModalWithData();
+      }
+      return;
+    }
+
     // Handle close button click
     if (target.closest('#settingsCancelBtn')) {
       closeSettingsModal();
@@ -821,6 +856,12 @@ export function openPersonalizeModal(currentLanguage = 'en') {
     categoryFilterToggle.checked = localStorage.getItem('categoryFilterEnabled') === 'true';
   }
 
+  // Notes collection toggle reflects whether the standalone notes overview is enabled
+  const notesCollectionToggle = document.getElementById('notesCollectionToggle');
+  if (notesCollectionToggle) {
+    notesCollectionToggle.checked = localStorage.getItem('notesCollectionEnabled') === 'true';
+  }
+
   // Update reminders toggle + dropdown state
   const remindersToggle = document.getElementById('remindersToggle');
   const remindersDaysContainer = document.getElementById('remindersDaysContainer');
@@ -910,6 +951,17 @@ export function openPersonalizeModal(currentLanguage = 'en') {
       }
       if (window.renderTasksCallback) {
         window.renderTasksCallback();
+      }
+      return;
+    }
+
+    // Handle notes collection toggle (show/hide the "Notizen" menu entry only)
+    if (target.id === 'notesCollectionToggle') {
+      const isEnabled = target.checked;
+      localStorage.setItem('notesCollectionEnabled', isEnabled.toString());
+
+      if (window.updateNotesMenuVisibility) {
+        window.updateNotesMenuVisibility();
       }
       return;
     }
@@ -1302,6 +1354,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   }
   document.getElementById('quickDueDateToggle')?.classList.remove('icon-toggle-checked');
 
+  // Reset notes field (always visible, not gated by any flag)
+  const quickAddNotes = document.getElementById('quickAddNotes');
+  if (quickAddNotes) {
+    quickAddNotes.value = '';
+  }
+
   // Show category selector only when the category filter feature is enabled,
   // and preselect the active calendar (Privat/Beruflich)
   const categoryConfig = document.getElementById('quickAddCategoryConfig');
@@ -1344,6 +1402,12 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
 
   // Update input placeholder
   quickAddInput.placeholder = lang.taskInputPlaceholder;
+
+  // Update notes placeholder
+  const quickAddNotesEl = document.getElementById('quickAddNotes');
+  if (quickAddNotesEl && lang.quickAddModal?.notesPlaceholder) {
+    quickAddNotesEl.placeholder = lang.quickAddModal.notesPlaceholder;
+  }
 
   // Update recurring label
   const quickRecurringEnableText = document.getElementById('quickRecurringEnableText');
@@ -1433,9 +1497,13 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
       category = activeBtn?.dataset.category || null;
     }
 
-    // Call callback with due date and category
+    // Get notes if provided (always available, not gated by any flag)
+    const notesInput = document.getElementById('quickAddNotes');
+    const notes = notesInput && notesInput.value.trim() ? notesInput.value.trim() : null;
+
+    // Call callback with due date, category and notes
     if (onAddTask) {
-      onAddTask(text, segmentId, recurringConfig, dueDate, category);
+      onAddTask(text, segmentId, recurringConfig, dueDate, category, notes);
     }
 
     // Close modal
@@ -1604,6 +1672,139 @@ export function openEditRecurringModal(task, onSave, translations, currentLangua
   const newCancelBtn = cancelBtn.cloneNode(true);
   cancelBtn.parentNode.replaceChild(newCancelBtn, cancelBtn);
   newCancelBtn.addEventListener('click', handleCancel);
+}
+
+/**
+ * Open edit-notes modal for an existing task (always available, Issue #371)
+ * @param {object} task - Task to edit
+ * @param {function} onSave - Callback(taskId, newNotes|null) when saved
+ * @param {object} translations - Translations object
+ * @param {string} currentLanguage - Current language
+ */
+export function openEditNotesModal(task, onSave, translations, currentLanguage) {
+  const modal = document.getElementById('editNotesModal');
+  const taskNameElement = document.getElementById('editNotesTaskName');
+  const titleElement = document.getElementById('editNotesTitle');
+  const textarea = document.getElementById('editNotesTextarea');
+  const saveBtn = document.getElementById('editNotesSaveBtn');
+  const cancelBtn = document.getElementById('editNotesCancelBtn');
+
+  if (!modal || !textarea) return;
+
+  const lang = translations[currentLanguage]?.editNotes;
+
+  taskNameElement.textContent = task.text;
+  titleElement.textContent = lang?.title || 'Edit note';
+  textarea.placeholder = lang?.placeholder || '';
+  textarea.value = task.notes || '';
+
+  modal.style.display = 'flex';
+  setTimeout(() => textarea.focus(), 100);
+
+  const handleSave = () => {
+    const value = textarea.value.trim();
+    onSave(task.id, value.length ? value : null);
+    modal.style.display = 'none';
+  };
+
+  const handleCancel = () => {
+    modal.style.display = 'none';
+  };
+
+  // Remove old listeners and add new ones
+  const newSaveBtn = saveBtn.cloneNode(true);
+  saveBtn.parentNode.replaceChild(newSaveBtn, saveBtn);
+  newSaveBtn.textContent = lang?.save || 'Save';
+  newSaveBtn.addEventListener('click', handleSave);
+
+  const newCancelBtn = cancelBtn.cloneNode(true);
+  cancelBtn.parentNode.replaceChild(newCancelBtn, cancelBtn);
+  newCancelBtn.textContent = lang?.cancel || 'Cancel';
+  newCancelBtn.addEventListener('click', handleCancel);
+}
+
+/**
+ * Render the standalone notes list (Issue #371)
+ * @param {Array} notesArray - Flat array of note objects
+ * @param {object} translations - Translations object
+ * @param {string} currentLanguage - Current language
+ * @param {object} callbacks - { onDelete(noteId) }
+ */
+export function renderNotesList(notesArray, translations, currentLanguage, callbacks = {}) {
+  const container = document.getElementById('notesListContainer');
+  if (!container) return;
+
+  const lang = translations[currentLanguage]?.notes;
+  container.innerHTML = '';
+
+  if (!notesArray.length) {
+    const empty = document.createElement('p');
+    empty.className = 'notes-empty-state';
+    empty.textContent = lang?.empty || 'No notes yet';
+    container.appendChild(empty);
+    return;
+  }
+
+  const sorted = [...notesArray].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+  const dateLocale = currentLanguage === 'de' ? 'de-DE' : 'en-US';
+
+  sorted.forEach((note) => {
+    const item = document.createElement('div');
+    item.className = 'note-item';
+    item.dataset.noteId = note.id;
+
+    const content = document.createElement('div');
+    content.className = 'note-item-content';
+
+    const textSpan = document.createElement('span');
+    textSpan.className = 'note-text';
+    textSpan.textContent = note.text;
+    content.appendChild(textSpan);
+
+    const dateSpan = document.createElement('span');
+    dateSpan.className = 'note-date';
+    dateSpan.textContent = new Date(note.createdAt).toLocaleDateString(dateLocale);
+    content.appendChild(dateSpan);
+
+    if (note.sourceTaskId) {
+      const badge = document.createElement('span');
+      badge.className = 'note-source-badge';
+      badge.textContent = `${lang?.sourceBadgePrefix || '→ Task'} ${note.sourceTaskId}`;
+      content.appendChild(badge);
+    }
+
+    item.appendChild(content);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'note-delete-btn';
+    deleteBtn.type = 'button';
+    deleteBtn.setAttribute('aria-label', lang?.deleteAriaLabel || 'Delete note');
+    deleteBtn.textContent = '✕';
+    deleteBtn.addEventListener('click', () => callbacks.onDelete?.(note.id));
+    item.appendChild(deleteBtn);
+
+    container.appendChild(item);
+  });
+}
+
+/**
+ * Open the standalone notes modal (Issue #371)
+ */
+export function openNotesModal() {
+  const modal = document.getElementById('notesModal');
+  if (modal) {
+    modal.style.display = 'flex';
+  }
+}
+
+/**
+ * Close the standalone notes modal
+ */
+export function closeNotesModal() {
+  const modal = document.getElementById('notesModal');
+  if (modal) {
+    modal.style.display = 'none';
+  }
 }
 
 /**

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -192,6 +192,17 @@ export function createTaskElement(task, translations, currentLanguage, callbacks
     }
   }
 
+  // Click on the task content re-opens the Quick Add dialog prefilled for
+  // editing (text, due date, recurring, category, notes). Inner controls
+  // (checkbox, recurring/notes indicator, delete button) already stop
+  // propagation, so they don't trigger this.
+  if (callbacks.onEditTask) {
+    content.classList.add('task-content-editable');
+    content.addEventListener('click', () => {
+      callbacks.onEditTask(task);
+    });
+  }
+
   div.appendChild(checkbox);
   div.appendChild(content);
 
@@ -1314,13 +1325,23 @@ export function updateMetricsLanguage(translations, currentLanguage) {
 }
 
 /**
- * Open Quick Add Modal for a specific segment
+ * Open Quick Add Modal for a specific segment. Pass `existingTask` to reuse
+ * the same dialog for editing: the fields are prefilled from the task and
+ * `onAddTask` is called with the task's id as a trailing argument so the
+ * caller can tell an edit apart from a fresh add (Issue: edit existing tasks).
  * @param {number} segmentId - Segment ID (1-5)
- * @param {function} onAddTask - Callback when task is added
+ * @param {function} onAddTask - Callback when task is added/edited: (text, segmentId, recurring, dueDate, category, notes, taskId)
  * @param {object} translations - Translations object
  * @param {string} currentLanguage - Current language
+ * @param {object|null} existingTask - Task to edit, or null to create a new task
  */
-export function openQuickAddModal(segmentId, onAddTask, translations, currentLanguage) {
+export function openQuickAddModal(
+  segmentId,
+  onAddTask,
+  translations,
+  currentLanguage,
+  existingTask = null
+) {
   const quickAddModal = document.getElementById('quickAddModal');
   const quickAddInput = document.getElementById('quickAddInput');
   const quickAddCategory = document.getElementById('quickAddCategory');
@@ -1335,7 +1356,7 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   }
 
   // Reset modal
-  quickAddInput.value = '';
+  quickAddInput.value = existingTask ? existingTask.text : '';
   quickRecurringEnabled.checked = false;
   quickRecurringOptions.classList.remove('expanded');
   document.getElementById('quickRecurringToggle')?.classList.remove('icon-toggle-checked');
@@ -1354,21 +1375,59 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   }
   document.getElementById('quickDueDateToggle')?.classList.remove('icon-toggle-checked');
 
-  // Reset notes field (always visible, not gated by any flag)
+  // Prefill recurring settings from the task being edited
+  if (existingTask?.recurring?.enabled) {
+    quickRecurringEnabled.checked = true;
+    quickRecurringOptions.classList.add('expanded');
+    document.getElementById('quickRecurringToggle')?.classList.add('icon-toggle-checked');
+
+    const recurringType = existingTask.recurring.interval || 'daily';
+    const typeRadio = document.querySelector(
+      `input[name="quickRecurringType"][value="${recurringType}"]`
+    );
+    if (typeRadio) typeRadio.checked = true;
+
+    if (recurringType === 'weekly') {
+      document.getElementById('quickWeekdaysContainer')?.classList.add('expanded');
+      const weekdays = existingTask.recurring.weekdays || [];
+      document.querySelectorAll('#quickWeekdaysContainer .weekday-check').forEach((cb) => {
+        cb.checked = weekdays.includes(parseInt(cb.value));
+      });
+    } else if (recurringType === 'monthly') {
+      document.getElementById('quickMonthDayContainer')?.classList.add('expanded');
+      const monthDayInput = document.getElementById('quickMonthDay');
+      if (monthDayInput) monthDayInput.value = existingTask.recurring.dayOfMonth || 1;
+    } else if (recurringType === 'custom') {
+      const customDaysInput = document.getElementById('quickCustomDays');
+      if (customDaysInput) customDaysInput.value = existingTask.recurring.customDays || 1;
+    }
+  }
+
+  // Prefill due date from the task being edited
+  if (existingTask?.dueDate && dueDateInput) {
+    dueDateInput.value = existingTask.dueDate;
+    dueDateInput.style.display = '';
+    if (quickDueDateEnabled) quickDueDateEnabled.checked = true;
+    document.getElementById('quickDueDateToggle')?.classList.add('icon-toggle-checked');
+  }
+
+  // Reset notes field (always visible, not gated by any flag), prefilled
+  // from the task being edited when applicable.
   const quickAddNotes = document.getElementById('quickAddNotes');
   if (quickAddNotes) {
-    quickAddNotes.value = '';
+    quickAddNotes.value = existingTask?.notes || '';
   }
 
   // Show category selector only when the category filter feature is enabled,
-  // and preselect the active calendar (Privat/Beruflich)
+  // and preselect the active calendar (Privat/Beruflich) — or the task's own
+  // category when editing.
   const categoryConfig = document.getElementById('quickAddCategoryConfig');
   if (categoryConfig) {
     const categoryFilterEnabled = localStorage.getItem('categoryFilterEnabled') === 'true';
     categoryConfig.style.display = categoryFilterEnabled ? '' : 'none';
-    // Preselect the active calendar so new tasks land in the current view;
-    // the user can still override it (incl. "Keine") per task.
-    const activeCategory = localStorage.getItem('categoryFilter') || '';
+    const activeCategory = existingTask
+      ? existingTask.category || ''
+      : localStorage.getItem('categoryFilter') || '';
     const categoryBtns = categoryConfig.querySelectorAll('.category-select-btn');
     categoryBtns.forEach((btn) => {
       btn.classList.toggle('active', (btn.dataset.category || '') === activeCategory);
@@ -1398,7 +1457,9 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
 
   // Update title and labels based on current language
   const lang = translations[currentLanguage];
-  quickAddTitle.textContent = currentLanguage === 'de' ? 'Neue Aufgabe' : 'New Task';
+  quickAddTitle.textContent = existingTask
+    ? lang.quickAddModal.editTitle
+    : lang.quickAddModal.title;
 
   // Update input placeholder
   quickAddInput.placeholder = lang.taskInputPlaceholder;
@@ -1501,9 +1562,17 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
     const notesInput = document.getElementById('quickAddNotes');
     const notes = notesInput && notesInput.value.trim() ? notesInput.value.trim() : null;
 
-    // Call callback with due date, category and notes
+    // Call callback with due date, category, notes and (when editing) the task id
     if (onAddTask) {
-      onAddTask(text, segmentId, recurringConfig, dueDate, category, notes);
+      onAddTask(
+        text,
+        segmentId,
+        recurringConfig,
+        dueDate,
+        category,
+        notes,
+        existingTask?.id ?? null
+      );
     }
 
     // Close modal
@@ -1513,7 +1582,7 @@ export function openQuickAddModal(segmentId, onAddTask, translations, currentLan
   // Remove old listeners and add new ones
   const newSubmitBtn = quickAddSubmitBtn.cloneNode(true);
   quickAddSubmitBtn.parentNode.replaceChild(newSubmitBtn, quickAddSubmitBtn);
-  newSubmitBtn.textContent = lang.buttons.ok;
+  newSubmitBtn.textContent = existingTask ? lang.buttons.save : lang.buttons.ok;
   newSubmitBtn.addEventListener('click', handleSubmit);
 
   // Handle Enter key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eisenhauer-matrix",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eisenhauer-matrix",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "@sentry/browser": "^10.58.0",
@@ -4636,16 +4636,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5538,9 +5538,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5622,9 +5622,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7017,9 +7017,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -7355,9 +7355,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -7375,7 +7375,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7433,9 +7433,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eisenhauer-matrix",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Eine moderne, mobile-first Progressive Web App zur Aufgabenverwaltung nach der Eisenhauer-Matrix-Methode.",
   "main": "index.html",
   "type": "module",

--- a/script.js
+++ b/script.js
@@ -55,6 +55,7 @@ import {
   applySmartRules,
   filterByCategory,
   sameTaskId,
+  updateTask,
 } from './js/modules/tasks.js';
 import {
   addNote,
@@ -244,6 +245,42 @@ function handleAddTask(
   }
 
   renderTasksWithCallbacks();
+}
+
+/**
+ * Edit an existing task's text, due date, recurring config, category and notes.
+ * Reuses the Quick Add modal, so the callback signature matches handleAddTask
+ * with a trailing taskId.
+ */
+function handleEditTask(taskText, segment, recurringConfig, dueDate, category, notes, taskId) {
+  if (!taskId || !taskText || taskText.trim() === '') return;
+
+  const updatedTask = updateTask(taskId, segment, {
+    text: taskText.trim(),
+    dueDate: dueDate || null,
+    recurring: recurringConfig,
+    category,
+    notes,
+  });
+
+  if (!updatedTask) return;
+
+  // Save to storage based on mode
+  if (currentUser && db && !isGuestMode) {
+    updateTaskInFirestore(updatedTask, currentUser.uid, db, window.firebase);
+  } else {
+    saveGuestTasks(tasks);
+  }
+
+  renderTasksWithCallbacks();
+}
+
+/**
+ * Open the Quick Add modal prefilled for editing a task
+ * @param {object} task - Task to edit
+ */
+function handleOpenEditTask(task) {
+  openQuickAddModal(task.segment, handleEditTask, translations, getCurrentLanguage(), task);
 }
 
 /**
@@ -550,6 +587,7 @@ function renderTasksWithCallbacks() {
     onEditNotes: handleEditNotes,
     onReorder: handleReorderTask,
     onDismissDemo: handleDismissDemo,
+    onEditTask: handleOpenEditTask,
   };
 
   try {

--- a/script.js
+++ b/script.js
@@ -57,6 +57,12 @@ import {
   sameTaskId,
 } from './js/modules/tasks.js';
 import {
+  addNote,
+  deleteNote,
+  getAllNotes,
+  setAllNotes as setAllNotesState,
+} from './js/modules/notes.js';
+import {
   initStorage,
   saveGuestTasks,
   loadGuestTasks,
@@ -64,6 +70,11 @@ import {
   saveTaskToFirestore,
   updateTaskInFirestore,
   deleteTaskFromFirestore,
+  saveGuestNotes,
+  loadGuestNotes,
+  loadUserNotes,
+  saveNoteToFirestore,
+  deleteNoteFromFirestore,
   exportData,
   importData,
   requestPersistentStorage,
@@ -77,6 +88,10 @@ import {
   openSettingsModal,
   openMetricsModal,
   openEditRecurringModal,
+  openEditNotesModal,
+  openNotesModal,
+  closeNotesModal,
+  renderNotesList,
   openTutorialModal,
   shouldShowTutorial,
   showDragHint,
@@ -188,9 +203,29 @@ async function loadAllTasks() {
 }
 
 /**
+ * Load all standalone notes (Guest or Firebase)
+ */
+async function loadAllNotes() {
+  if (currentUser && db && !isGuestMode) {
+    const loadedNotes = await loadUserNotes(currentUser.uid, db);
+    setAllNotesState(loadedNotes);
+  } else {
+    const loadedNotes = await loadGuestNotes();
+    setAllNotesState(loadedNotes);
+  }
+}
+
+/**
  * Add task handler
  */
-function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null, category = null) {
+function handleAddTask(
+  taskText,
+  segment,
+  recurringConfig = null,
+  dueDate = null,
+  category = null,
+  notes = null
+) {
   if (!taskText || taskText.trim() === '') return;
 
   // First real task ends onboarding for good, so demo tasks/explanations
@@ -200,7 +235,7 @@ function handleAddTask(taskText, segment, recurringConfig = null, dueDate = null
   // The Quick Add modal already encodes the category choice (it preselects the
   // active calendar and lets the user override it, including "Keine"), so the
   // explicitly passed category is used as-is and never silently overridden.
-  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate, category);
+  const task = addTaskToSegment(taskText, segment, recurringConfig, null, dueDate, category, notes);
 
   // Save to storage based on mode
   if (currentUser && db && !isGuestMode) {
@@ -472,6 +507,40 @@ function handleEditRecurring(task) {
 }
 
 /**
+ * Handle edit task notes (always available, not gated by any flag, Issue #371)
+ * @param {object} task - Task to edit
+ */
+function handleEditNotes(task) {
+  openEditNotesModal(
+    task,
+    (taskId, newNotes) => {
+      for (const segment in tasks) {
+        const taskIndex = tasks[segment].findIndex((t) => sameTaskId(t.id, taskId));
+        if (taskIndex !== -1) {
+          if (newNotes === null) {
+            delete tasks[segment][taskIndex].notes;
+          } else {
+            tasks[segment][taskIndex].notes = newNotes;
+          }
+
+          const updatedTask = tasks[segment][taskIndex];
+          if (currentUser && db && !isGuestMode) {
+            updateTaskInFirestore(updatedTask, currentUser.uid, db, window.firebase);
+          } else {
+            saveGuestTasks(tasks);
+          }
+
+          renderTasksWithCallbacks();
+          break;
+        }
+      }
+    },
+    translations,
+    getCurrentLanguage()
+  );
+}
+
+/**
  * Render all tasks with all callbacks (Drag & Drop 2.0)
  */
 function renderTasksWithCallbacks() {
@@ -481,6 +550,7 @@ function renderTasksWithCallbacks() {
     onDragEnd: handleMoveTask,
     onSwipeDelete: handleDeleteTask,
     onEditRecurring: handleEditRecurring,
+    onEditNotes: handleEditNotes,
     onReorder: handleReorderTask,
     onDismissDemo: handleDismissDemo,
   };
@@ -589,8 +659,8 @@ function setupEventListeners() {
         // Open Quick Add Modal with Q1 (Do!) pre-selected
         openQuickAddModal(
           1, // Segment 1 (Do!)
-          (text, selectedSegment, recurring, dueDate, category) => {
-            handleAddTask(text, selectedSegment || 1, recurring, dueDate, category);
+          (text, selectedSegment, recurring, dueDate, category, notes) => {
+            handleAddTask(text, selectedSegment || 1, recurring, dueDate, category, notes);
           },
           translations,
           getCurrentLanguage()
@@ -647,8 +717,8 @@ function setupEventListeners() {
       const segment = parseInt(e.target.dataset.segment);
       openQuickAddModal(
         segment,
-        (text, selectedSegment, recurring, dueDate, category) => {
-          handleAddTask(text, selectedSegment || segment, recurring, dueDate, category);
+        (text, selectedSegment, recurring, dueDate, category, notes) => {
+          handleAddTask(text, selectedSegment || segment, recurring, dueDate, category, notes);
         },
         translations,
         getCurrentLanguage()
@@ -724,6 +794,75 @@ function setupEventListeners() {
         renderTasksWithCallbacks();
       });
     });
+  }
+
+  // Notes collection menu entry (Issue #371) - visibility only, task-notes stay
+  // available regardless of this flag.
+  const notesSection = document.getElementById('notesSection');
+  const notesSeparator = document.getElementById('notesSeparator');
+  if (notesSection) {
+    const updateNotesMenuVisibility = () => {
+      const enabled = localStorage.getItem('notesCollectionEnabled') === 'true';
+      notesSection.style.display = enabled ? '' : 'none';
+      if (notesSeparator) notesSeparator.style.display = enabled ? '' : 'none';
+    };
+    updateNotesMenuVisibility();
+    window.updateNotesMenuVisibility = updateNotesMenuVisibility;
+  }
+
+  // Standalone notes modal (Issue #371)
+  const renderNotesListWithCallbacks = () => {
+    renderNotesList(getAllNotes(), translations, getCurrentLanguage(), {
+      onDelete: handleDeleteNote,
+    });
+  };
+  window.openNotesModalWithData = () => {
+    openNotesModal();
+    renderNotesListWithCallbacks();
+  };
+
+  const notesCancelBtn = document.getElementById('notesCancelBtn');
+  if (notesCancelBtn) {
+    notesCancelBtn.addEventListener('click', () => closeNotesModal());
+  }
+
+  const notesAddBtn = document.getElementById('notesAddBtn');
+  const notesAddInput = document.getElementById('notesAddInput');
+  const handleAddNote = () => {
+    const text = notesAddInput.value.trim();
+    if (!text) return;
+
+    const note = addNote(text);
+    if (currentUser && db && !isGuestMode) {
+      saveNoteToFirestore(note, currentUser.uid, db);
+    } else {
+      saveGuestNotes(getAllNotes());
+    }
+
+    notesAddInput.value = '';
+    renderNotesListWithCallbacks();
+  };
+  if (notesAddBtn && notesAddInput) {
+    notesAddBtn.addEventListener('click', handleAddNote);
+    notesAddInput.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleAddNote();
+      }
+    });
+  }
+
+  function handleDeleteNote(noteId) {
+    const removed = deleteNote(noteId);
+    if (!removed) return;
+
+    if (currentUser && db && !isGuestMode) {
+      deleteNoteFromFirestore(removed.id, currentUser.uid, db);
+    } else {
+      saveGuestNotes(getAllNotes());
+    }
+
+    renderNotesListWithCallbacks();
   }
 
   // Settings button (header)
@@ -1227,6 +1366,7 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
     } else {
       await loadAllTasks();
     }
+    await loadAllNotes();
 
     // Wait for DOM to be fully visible after showApp()
     setTimeout(() => {
@@ -1279,6 +1419,7 @@ window.onAuthStateChanged = async function (user, guestMode = false) {
   } else {
     // Tasks already loaded: just re-sync with Firebase in background
     await loadAllTasks();
+    await loadAllNotes();
     renderTasksWithCallbacks();
   }
 };
@@ -1370,6 +1511,7 @@ async function initApp() {
       isGuestMode = true;
       window.showApp();
       await loadAllTasks();
+      await loadAllNotes();
       setupEventListeners();
       if (!keyboardDragManager) {
         keyboardDragManager = new KeyboardDragManager(handleMoveTask);
@@ -1382,6 +1524,7 @@ async function initApp() {
       isGuestMode = false;
       window.showApp();
       await loadAllTasks();
+      await loadAllNotes();
       setupEventListeners();
       if (!keyboardDragManager) {
         keyboardDragManager = new KeyboardDragManager(handleMoveTask);

--- a/script.js
+++ b/script.js
@@ -68,6 +68,7 @@ import {
   loadGuestTasks,
   loadUserTasks,
   saveTaskToFirestore,
+  saveAllTasksToFirestore,
   updateTaskInFirestore,
   deleteTaskFromFirestore,
   saveGuestNotes,
@@ -167,17 +168,13 @@ window.importGuestTasksToFirestore = importGuestTasksToFirestore;
  * Save all tasks (Guest or Firebase)
  * Note: For Firebase users, this function is not typically called since
  * individual task operations (add/update/delete) save directly to Firestore.
- * This function is mainly used for bulk operations like import.
+ * This function is mainly used for bulk operations like reorder and import,
+ * where it writes all tasks in one or more Firestore batches instead of
+ * sequential per-task writes (see saveAllTasksToFirestore).
  */
 async function saveAllTasks() {
   if (currentUser && db && !isGuestMode) {
-    // For logged-in users, save each task individually to Firestore
-    const { saveTaskToFirestore } = await import('./js/modules/storage.js');
-    for (const segmentId in tasks) {
-      for (const task of tasks[segmentId]) {
-        await saveTaskToFirestore(task, currentUser.uid, db, window.firebase);
-      }
-    }
+    await saveAllTasksToFirestore(tasks, currentUser.uid, db);
   } else {
     await saveGuestTasks(tasks);
   }

--- a/script.js
+++ b/script.js
@@ -1138,6 +1138,10 @@ function setupEventListeners() {
       quickAddDueDate.style.display = checked ? '' : 'none';
       quickDueDateToggle?.classList.toggle('icon-toggle-checked', checked);
       if (checked) {
+        // Force a layout flush so the browser registers the input as
+        // rendered before showPicker() checks for it, otherwise it can
+        // throw InvalidStateError right after toggling display:none off.
+        void quickAddDueDate.offsetHeight;
         if (typeof quickAddDueDate.showPicker === 'function') {
           try {
             quickAddDueDate.showPicker();

--- a/style.css
+++ b/style.css
@@ -861,6 +861,10 @@ header h1,
   gap: 4px;
 }
 
+.task-content-editable {
+  cursor: pointer;
+}
+
 .task-text {
   flex: 1;
   color: var(--text-primary);

--- a/tests/unit/notes.test.js
+++ b/tests/unit/notes.test.js
@@ -1,0 +1,120 @@
+/**
+ * Unit Tests for Notes Module (Issue #371)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  generateNoteId,
+  addNote,
+  deleteNote,
+  getAllNotes,
+  setAllNotes,
+} from '../../js/modules/notes.js';
+
+describe('Notes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T10:00:00Z'));
+    setAllNotes([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('generateNoteId', () => {
+    it('should generate unique string IDs', () => {
+      const id1 = generateNoteId();
+      const id2 = generateNoteId();
+      expect(id1).not.toBe(id2);
+      expect(typeof id1).toBe('string');
+    });
+
+    it('should fall back to a timestamp-based ID when crypto.randomUUID is unavailable', () => {
+      vi.stubGlobal('crypto', undefined);
+
+      const id = generateNoteId();
+      expect(id).toMatch(/^note-/);
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe('addNote', () => {
+    it('should create a note with id, text and createdAt', () => {
+      const note = addNote('Buy milk');
+
+      expect(note).toMatchObject({ text: 'Buy milk', createdAt: Date.now() });
+      expect(note.id).toBeTruthy();
+      expect(getAllNotes()).toHaveLength(1);
+      expect(getAllNotes()[0]).toBe(note);
+    });
+
+    it('should trim note text', () => {
+      const note = addNote('  spaced out  ');
+      expect(note.text).toBe('spaced out');
+    });
+
+    it('should invoke the save callback with the created note', () => {
+      const saveCallback = vi.fn();
+      const note = addNote('Call dentist', saveCallback);
+      expect(saveCallback).toHaveBeenCalledWith(note);
+    });
+
+    it('should set sourceTaskId when provided', () => {
+      const note = addNote('From a task', null, 'task-123');
+      expect(note.sourceTaskId).toBe('task-123');
+    });
+
+    it('should not set sourceTaskId when not provided', () => {
+      const note = addNote('Standalone');
+      expect(note).not.toHaveProperty('sourceTaskId');
+    });
+
+    it('should reject non-string text', () => {
+      expect(() => addNote(42)).toThrow(TypeError);
+    });
+
+    it('should reject empty text', () => {
+      expect(() => addNote('   ')).toThrow('Note text cannot be empty');
+    });
+
+    it('should reject text over 500 characters', () => {
+      expect(() => addNote('x'.repeat(501))).toThrow('Note text must not exceed 500 characters');
+    });
+  });
+
+  describe('deleteNote', () => {
+    it('should remove a note by ID and return it', () => {
+      const note = addNote('Delete me');
+      const deleteCallback = vi.fn();
+
+      const removed = deleteNote(note.id, deleteCallback);
+
+      expect(removed).toBe(note);
+      expect(deleteCallback).toHaveBeenCalledWith(note);
+      expect(getAllNotes()).toHaveLength(0);
+    });
+
+    it('should return null and leave the array untouched for an unknown ID', () => {
+      addNote('Keep me');
+      const removed = deleteNote('unknown-id');
+
+      expect(removed).toBeNull();
+      expect(getAllNotes()).toHaveLength(1);
+    });
+  });
+
+  describe('getAllNotes / setAllNotes', () => {
+    it('should round-trip a notes array', () => {
+      const notes = [{ id: '1', text: 'A', createdAt: 1 }];
+      setAllNotes(notes);
+      expect(getAllNotes()).toBe(notes);
+    });
+
+    it('should default to an empty array for non-array input', () => {
+      setAllNotes(null);
+      expect(getAllNotes()).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -3,6 +3,23 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Firestore is mocked so updateTaskInFirestore can be asserted on without a
+// live connection. deleteField() returns a recognisable sentinel instead of the
+// real FieldValue instance.
+const DELETE_SENTINEL = Symbol('deleteField');
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({})),
+  doc: vi.fn(() => ({})),
+  getDocs: vi.fn(async () => ({ forEach: () => {} })),
+  setDoc: vi.fn(async () => {}),
+  deleteDoc: vi.fn(async () => {}),
+  deleteField: vi.fn(() => DELETE_SENTINEL),
+  writeBatch: vi.fn(() => ({ set: vi.fn(), commit: vi.fn(async () => {}) })),
+  serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
+}));
+
 import {
   getSyncStatus,
   exportData,
@@ -13,7 +30,9 @@ import {
   saveGuestNotes,
   loadGuestNotes,
   importData,
+  updateTaskInFirestore,
 } from '../../js/modules/storage.js';
+import { setDoc } from 'firebase/firestore';
 import localforage from 'localforage';
 
 describe('Storage Module', () => {
@@ -598,6 +617,90 @@ describe('Storage Module', () => {
       await expect(importData(file, {}, null)).rejects.toThrow('Fehler beim Lesen der Datei');
 
       global.FileReader = originalFileReader;
+    });
+  });
+
+  describe('updateTaskInFirestore clearable fields', () => {
+    const userId = 'user-1';
+    const db = {};
+
+    // setDoc runs via the offline queue, so wait until it has been called
+    // instead of assuming it happened synchronously.
+    const writtenData = async () => {
+      await vi.waitFor(() => expect(setDoc).toHaveBeenCalled());
+      return setDoc.mock.calls.at(-1)[1];
+    };
+
+    beforeEach(() => {
+      setDoc.mockClear();
+    });
+
+    it('should write optional fields when they have a value', async () => {
+      await updateTaskInFirestore(
+        {
+          id: 't1',
+          text: 'Task',
+          segment: 1,
+          createdAt: 123,
+          completedAt: 456,
+          dueDate: '2026-08-20',
+          category: 'business',
+          notes: 'Some note',
+          recurring: { enabled: true, interval: 'daily' },
+        },
+        userId,
+        db
+      );
+
+      expect(await writtenData()).toMatchObject({
+        completedAt: 456,
+        dueDate: '2026-08-20',
+        category: 'business',
+        notes: 'Some note',
+        recurring: { enabled: true, interval: 'daily' },
+      });
+    });
+
+    it('should delete cleared fields instead of omitting them', async () => {
+      // setDoc uses merge:true, so an omitted field would keep its stale value
+      // in Firestore and the cleared value would reappear on the next load.
+      await updateTaskInFirestore(
+        {
+          id: 't1',
+          text: 'Task',
+          segment: 1,
+          createdAt: 123,
+          completedAt: null,
+          dueDate: null,
+          category: null,
+          notes: null,
+          recurring: null,
+        },
+        userId,
+        db
+      );
+
+      const data = await writtenData();
+      expect(data.completedAt).toBe(DELETE_SENTINEL);
+      expect(data.dueDate).toBe(DELETE_SENTINEL);
+      expect(data.category).toBe(DELETE_SENTINEL);
+      expect(data.notes).toBe(DELETE_SENTINEL);
+      expect(data.recurring).toBe(DELETE_SENTINEL);
+    });
+
+    it('should delete fields that are absent from the task object', async () => {
+      await updateTaskInFirestore(
+        { id: 't1', text: 'Task', segment: 1, createdAt: 123 },
+        userId,
+        db
+      );
+
+      const data = await writtenData();
+      expect(data.dueDate).toBe(DELETE_SENTINEL);
+      expect(data.category).toBe(DELETE_SENTINEL);
+      expect(data.notes).toBe(DELETE_SENTINEL);
+      expect(data.recurring).toBe(DELETE_SENTINEL);
+      expect(data.completedAt).toBe(DELETE_SENTINEL);
     });
   });
 });

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -10,6 +10,8 @@ import {
   checkPersistentStorage,
   saveGuestTasks,
   loadGuestTasks,
+  saveGuestNotes,
+  loadGuestNotes,
   importData,
 } from '../../js/modules/storage.js';
 import localforage from 'localforage';
@@ -383,6 +385,59 @@ describe('Storage Module', () => {
 
       // Should return empty structure on parse error
       expect(result).toEqual({ 1: [], 2: [], 3: [], 4: [], 5: [] });
+    });
+  });
+
+  describe('saveGuestNotes (Issue #371)', () => {
+    it('should save notes to localforage', async () => {
+      const notes = [{ id: 'n1', text: 'Note 1', createdAt: 1 }];
+
+      const setItemSpy = vi.spyOn(localforage, 'setItem').mockResolvedValue(undefined);
+
+      await saveGuestNotes(notes);
+
+      expect(setItemSpy).toHaveBeenCalledWith('eisenhauer-notes', notes);
+    });
+
+    it('should handle errors gracefully', async () => {
+      vi.spyOn(localforage, 'setItem').mockRejectedValue(new Error('Storage full'));
+
+      await expect(saveGuestNotes([])).resolves.not.toThrow();
+    });
+  });
+
+  describe('loadGuestNotes (Issue #371)', () => {
+    it('should load notes from localforage', async () => {
+      const notes = [{ id: 'n1', text: 'Note 1', createdAt: 1 }];
+      vi.spyOn(localforage, 'getItem').mockResolvedValue(notes);
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual(notes);
+    });
+
+    it('should return an empty array when no data exists', async () => {
+      vi.spyOn(localforage, 'getItem').mockResolvedValue(null);
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array on error', async () => {
+      vi.spyOn(localforage, 'getItem').mockRejectedValue(new Error('DB Error'));
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array for non-array stored data', async () => {
+      vi.spyOn(localforage, 'getItem').mockResolvedValue('not-an-array');
+
+      const result = await loadGuestNotes();
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/tests/unit/tasks.test.js
+++ b/tests/unit/tasks.test.js
@@ -109,6 +109,41 @@ describe('Tasks', () => {
       expect(() => restoreTask({ segment: SEGMENTS.DO })).toThrow('Task ID is required');
     });
 
+    it('should set notes when provided and omit the field otherwise (Issue #371)', () => {
+      const withNotes = addTaskToSegment(
+        'Buy groceries',
+        SEGMENTS.DO,
+        null,
+        null,
+        null,
+        null,
+        'Remember the oat milk'
+      );
+      expect(withNotes.notes).toBe('Remember the oat milk');
+
+      const withoutNotes = addTaskToSegment('No notes here', SEGMENTS.DO);
+      expect(withoutNotes).not.toHaveProperty('notes');
+    });
+
+    it('should validate notes input', () => {
+      expect(() => addTaskToSegment('Task', SEGMENTS.DO, null, null, null, null, 42)).toThrow(
+        TypeError
+      );
+      expect(() =>
+        addTaskToSegment('Task', SEGMENTS.DO, null, null, null, null, 'x'.repeat(501))
+      ).toThrow('Notes must not exceed 500 characters');
+    });
+
+    it('should set or clear notes via updateTask', () => {
+      const task = addTaskToSegment('Task', SEGMENTS.DO);
+
+      updateTask(task.id, SEGMENTS.DO, { notes: 'A quick note' });
+      expect(getTask(task.id, SEGMENTS.DO).notes).toBe('A quick note');
+
+      updateTask(task.id, SEGMENTS.DO, { notes: null });
+      expect(getTask(task.id, SEGMENTS.DO).notes).toBeNull();
+    });
+
     it('should restore and delete tasks with callbacks', () => {
       const task = {
         id: 101,


### PR DESCRIPTION
## Beschreibung

Release-PR `testing` → `main`. Bündelt 13 Commits, die seit dem letzten Main-Merge (`b2d8e69`, 22.07.2026) auf `testing` gelandet sind.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)
- [x] Bugfix (non-breaking change)
- [x] Dokumentation Update

## Enthaltene Änderungen

- Notizfunktion: Task-Notizen + freistehende Notizen-Sammlung (#373, Issue #371)
- Bestehende Aufgaben bearbeiten (Quick-Add-Modal wiederverwenden) (#378/#379)
- Fix: Fälligkeitsdatum-Kalender öffnet sich nicht (#372, Issue #369)
- Fix: Edge-to-Edge-Deprecations (#368) + Batch-Writes für saveAllTasks (#337) (#374)
- Fix(android): blanket androidx-keep aus ProGuard-Regeln entfernen (Issue #367) (#375)
- Docs: R8/ProGuard-Fix (#367) in CLAUDE.md festhalten, Gerätetest-Pflicht dokumentieren (#376)
- chore: aab-archive/ zu .gitignore hinzufügen (#366)
- chore: version bump auf 1.12.2 (versionCode 27)
- fix: update transitive deps to close npm audit findings (#380)
- CI-Workflows nur noch bei PRs gegen main triggern (#381)

## Testing Checklist

- [x] CI/CD auf `testing` (HEAD `6d1fb1a`) grün
- [ ] Merge erfolgt erst nach expliziter schriftlicher Freigabe (siehe CLAUDE.md Global Policy)

## Zusätzliche Notizen

**Nicht mergen** — dieser PR dient nur zur Vorbereitung/Review. Merge auf `main` erfolgt laut Projekt-Policy erst nach separater expliziter Freigabe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjdmgN5nXnsrr7HsCXpstD)_