### PR TITLE
fix: geleerte Task-Felder per deleteField() aus Firestore entfernen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,20 @@ Klick auf den Task-Text öffnet das bestehende Quick-Add-Modal (`openQuickAddMod
 - **Kein Segment-Wechsel im Edit-Modus** – das Modal hat keinen Segment-Picker, Editieren ändert nur Text/Fälligkeit/Wiederholung/Kategorie/Notiz im selben Quadranten.
 - i18n: neue Keys `buttons.save` und `quickAddModal.editTitle` in `translations.js` (de/en).
 
+### Optionale Task-Felder löschen: `deleteField()` statt Feld weglassen
+
+`updateTaskInFirestore()` in `js/modules/storage.js` schreibt mit `setDoc(..., { merge: true })`. Ein **weggelassenes** Feld bedeutet dort „alten Wert behalten" – nicht „Feld löschen". Optionale Felder, die der Nutzer leeren kann, dürfen deshalb nie über ein `if (task.x) { updateData.x = task.x; }` geschrieben werden, sondern müssen den leeren Fall explizit als `deleteField()` senden:
+
+```js
+updateData.dueDate = task.dueDate ? task.dueDate : deleteField();
+```
+
+Betroffen sind `completedAt`, `recurring`, `dueDate`, `category` und `notes`. Vorher war nur `notes` so umgesetzt (PR #373); die übrigen vier hatten den Bug, was durch den Edit-Dialog aus PR #378 sichtbar wurde: Fälligkeit/Kategorie im Dialog leeren → lokal korrekt weg → nach dem Reload wieder da. `completedAt` traf es beim Abwählen einer erledigten Aufgabe (`task.completedAt = null` in `tasks.js`), was die Metriken verfälscht.
+
+- **Nur der Firebase-Modus war betroffen** – `saveGuestTasks()` serialisiert das Task-Objekt komplett und kennt das Problem nicht.
+- Regression-Tests in `tests/unit/storage.test.js` (`describe('updateTaskInFirestore clearable fields')`) mit gemocktem `firebase/firestore`. **Achtung:** Diese Suite ist in der CI per `--exclude` ausgeschlossen, die Tests laufen also nur lokal über `npm test`.
+- Beim Ergänzen weiterer optionaler Task-Felder: immer dem `deleteField()`-Muster folgen.
+
 ## Test-Coverage (Stand 2026-06-19)
 
 Gemessen über 9 Unit-Test-Suites (ohne `storage.test.js`, die Firebase-Credentials benötigt):

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -360,26 +360,17 @@ export async function updateTaskInFirestore(task, userId, db) {
     createdAt: task.createdAt || serverTimestamp(),
   };
 
-  if (task.completedAt) {
-    updateData.completedAt = task.completedAt;
-  }
-
-  if (task.recurring) {
-    updateData.recurring = task.recurring;
-  }
-
-  if (task.dueDate) {
-    updateData.dueDate = task.dueDate;
-  }
-
-  if (task.category) {
-    updateData.category = task.category;
-  }
-
   // setDoc uses merge:true below, so an omitted field would just keep its old
-  // value in Firestore. Notes are user-clearable (empty the textarea to
-  // remove a note), so an absent/empty value must explicitly delete the
-  // field rather than silently leaving a stale one behind.
+  // value in Firestore. Every optional field here is user-clearable — the edit
+  // dialog can drop the due date, the category ("Keine"), the notes and the
+  // recurring config, and un-checking a Done task resets completedAt — so an
+  // absent/empty value must explicitly delete the field rather than silently
+  // leaving a stale one behind. Without this the cleared value reappears on
+  // the next load (Issue: clearing fields did not persist for signed-in users).
+  updateData.completedAt = task.completedAt ? task.completedAt : deleteField();
+  updateData.recurring = task.recurring ? task.recurring : deleteField();
+  updateData.dueDate = task.dueDate ? task.dueDate : deleteField();
+  updateData.category = task.category ? task.category : deleteField();
   updateData.notes = task.notes ? task.notes : deleteField();
 
   // Add to offline queue with retry logic

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -3,6 +3,23 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Firestore is mocked so updateTaskInFirestore can be asserted on without a
+// live connection. deleteField() returns a recognisable sentinel instead of the
+// real FieldValue instance.
+const DELETE_SENTINEL = Symbol('deleteField');
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({})),
+  doc: vi.fn(() => ({})),
+  getDocs: vi.fn(async () => ({ forEach: () => {} })),
+  setDoc: vi.fn(async () => {}),
+  deleteDoc: vi.fn(async () => {}),
+  deleteField: vi.fn(() => DELETE_SENTINEL),
+  writeBatch: vi.fn(() => ({ set: vi.fn(), commit: vi.fn(async () => {}) })),
+  serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
+}));
+
 import {
   getSyncStatus,
   exportData,
@@ -13,7 +30,9 @@ import {
   saveGuestNotes,
   loadGuestNotes,
   importData,
+  updateTaskInFirestore,
 } from '../../js/modules/storage.js';
+import { setDoc } from 'firebase/firestore';
 import localforage from 'localforage';
 
 describe('Storage Module', () => {
@@ -598,6 +617,90 @@ describe('Storage Module', () => {
       await expect(importData(file, {}, null)).rejects.toThrow('Fehler beim Lesen der Datei');
 
       global.FileReader = originalFileReader;
+    });
+  });
+
+  describe('updateTaskInFirestore clearable fields', () => {
+    const userId = 'user-1';
+    const db = {};
+
+    // setDoc runs via the offline queue, so wait until it has been called
+    // instead of assuming it happened synchronously.
+    const writtenData = async () => {
+      await vi.waitFor(() => expect(setDoc).toHaveBeenCalled());
+      return setDoc.mock.calls.at(-1)[1];
+    };
+
+    beforeEach(() => {
+      setDoc.mockClear();
+    });
+
+    it('should write optional fields when they have a value', async () => {
+      await updateTaskInFirestore(
+        {
+          id: 't1',
+          text: 'Task',
+          segment: 1,
+          createdAt: 123,
+          completedAt: 456,
+          dueDate: '2026-08-20',
+          category: 'business',
+          notes: 'Some note',
+          recurring: { enabled: true, interval: 'daily' },
+        },
+        userId,
+        db
+      );
+
+      expect(await writtenData()).toMatchObject({
+        completedAt: 456,
+        dueDate: '2026-08-20',
+        category: 'business',
+        notes: 'Some note',
+        recurring: { enabled: true, interval: 'daily' },
+      });
+    });
+
+    it('should delete cleared fields instead of omitting them', async () => {
+      // setDoc uses merge:true, so an omitted field would keep its stale value
+      // in Firestore and the cleared value would reappear on the next load.
+      await updateTaskInFirestore(
+        {
+          id: 't1',
+          text: 'Task',
+          segment: 1,
+          createdAt: 123,
+          completedAt: null,
+          dueDate: null,
+          category: null,
+          notes: null,
+          recurring: null,
+        },
+        userId,
+        db
+      );
+
+      const data = await writtenData();
+      expect(data.completedAt).toBe(DELETE_SENTINEL);
+      expect(data.dueDate).toBe(DELETE_SENTINEL);
+      expect(data.category).toBe(DELETE_SENTINEL);
+      expect(data.notes).toBe(DELETE_SENTINEL);
+      expect(data.recurring).toBe(DELETE_SENTINEL);
+    });
+
+    it('should delete fields that are absent from the task object', async () => {
+      await updateTaskInFirestore(
+        { id: 't1', text: 'Task', segment: 1, createdAt: 123 },
+        userId,
+        db
+      );
+
+      const data = await writtenData();
+      expect(data.dueDate).toBe(DELETE_SENTINEL);
+      expect(data.category).toBe(DELETE_SENTINEL);
+      expect(data.notes).toBe(DELETE_SENTINEL);
+      expect(data.recurring).toBe(DELETE_SENTINEL);
+      expect(data.completedAt).toBe(DELETE_SENTINEL);
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Beschreibung

Aufgefallen beim Review von PR #382 (Release `testing` → `main`).

`updateTaskInFirestore()` in `js/modules/storage.js` schreibt mit `setDoc(..., { merge: true })`. Ein **weggelassenes** Feld bedeutet dort „alten Wert behalten" — nicht „Feld löschen". `completedAt`, `recurring`, `dueDate` und `category` wurden aber nur bedingt geschrieben:

```js
if (task.dueDate)  { updateData.dueDate  = task.dueDate; }
if (task.category) { updateData.category = task.category; }
```

Ein geleertes Feld blieb dadurch in Firestore stehen und tauchte beim nächsten Laden wieder auf. `notes` war in PR #373 bereits korrekt per `deleteField()` gelöst — inklusive eines Kommentars, der das Problem exakt beschreibt. Dieses Muster gilt jetzt einheitlich für alle fünf optionalen Felder.

**Reproduktion (vor dem Fix, nur angemeldet):**

1. Aufgabe mit Fälligkeit `2026-08-20` anlegen.
2. Auf den Task-Text klicken → Edit-Dialog (PR #378), Fälligkeits-Toggle ausschalten.
3. „Speichern" → die Liste rendert korrekt ohne Datum.
4. Seite neu laden → **Datum ist wieder da.**

Identisch beim Setzen der Kategorie auf „Keine". `completedAt` traf es auf einem anderen Weg: `tasks.js` setzt beim Abwählen einer erledigten Aufgabe `task.completedAt = null`, was in Firestore ebenfalls nie ankam und damit die Metriken verfälscht hat. Der Bug in `recurring` bestand schon länger über `openEditRecurringModal`, der Edit-Dialog aus PR #378 hat ihn nur für zwei weitere Felder sichtbar gemacht.

**Nur der Firebase-Modus war betroffen** — `saveGuestTasks()` serialisiert das Task-Objekt komplett und kennt das Problem nicht.

## Art der Änderung

- [x] Bugfix (non-breaking change)
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

Die Änderung liegt ausschließlich im Firestore-Schreibpfad (`js/modules/storage.js`) und im zugehörigen Unit-Test. Keine neuen `window`-/`document`-/`localStorage`-Zugriffe, kein Android-Code berührt.

## Testing Checklist

- [x] Lokaler Build erfolgreich
- [x] Keine TypeScript Errors (Projekt ist reines JS)
- [x] Keine neuen ESLint Warnings (unverändert 2 vorbestehende in `update-version.js`)
- [x] App startet ohne Crashes
- [x] Geänderte Features funktionieren wie erwartet

**Tests:** `npm test` lokal grün — 12 Suites, 262 Tests (vorher 259).

Neu in `tests/unit/storage.test.js`: `describe('updateTaskInFirestore clearable fields')` mit gemocktem `firebase/firestore`, wobei `deleteField()` ein erkennbares Sentinel liefert. Drei Tests: Felder mit Wert werden geschrieben, geleerte Felder (`null`) werden gelöscht, komplett fehlende Felder werden gelöscht.

Gegenprobe gemacht — mit dem alten `storage.js` schlagen genau die beiden Lösch-Tests fehl (`expected undefined to be Symbol(deleteField)`), der Positiv-Test bleibt grün. Der Test greift also wirklich.

⚠️ **Hinweis:** `tests/unit/storage.test.js` ist in der CI per `--exclude` ausgeschlossen (die Suite brauchte historisch Firebase-Credentials). Die neuen Tests laufen daher **nur lokal** über `npm test` und gaten die CI nicht.

## Screenshots / Videos

Keine UI-Änderung — der Fix betrifft nur, was in Firestore geschrieben wird. Der sichtbare Unterschied zeigt sich erst nach einem Reload (siehe Reproduktion oben).

## Zusätzliche Notizen

- **Manueller Gegentest empfohlen**, da die Suite nicht in der CI läuft: angemeldet eine Aufgabe mit Fälligkeit anlegen → editieren → Fälligkeit ausschalten → speichern → Seite neu laden. Das Datum darf nicht zurückkommen.
- `updateData` wird weiterhin als Metadaten an `offlineQueue.add(...)` übergeben und landet damit in IndexedDB. Die `deleteField()`-Sentinels sind keine plain Objects; `_saveQueue()` fängt Persistenz-Fehler aber ab („non-fatal") und der tatsächliche Schreibvorgang läuft über die im Speicher gehaltene Executor-Closure, nicht über die Metadaten. Das war mit dem bereits gemergten `notes`-Fix genauso und ändert sich hier nicht — erwähnt der Vollständigkeit halber.
- `CLAUDE.md` dokumentiert das `deleteField()`-Muster jetzt als Regel für künftige optionale Task-Felder.

Weitere Punkte aus dem Review von #382 (Offline-Queue beim Bulk-Save, Gast→Login-Migration der freistehenden Notizen, Click-Unterdrückung nach Long-Press) sind hier **bewusst nicht enthalten** und gehören in eigene Issues.

## Reviewer Checklist

**Für den Reviewer:**

- [ ] Code folgt den Projekt-Konventionen
- [ ] Keine Web APIs ohne Platform-Check
- [ ] Keine Hard-coded Values (Config/Env Vars verwenden)
- [ ] Error Handling vorhanden
- [ ] Keine sensiblen Daten im Code
- [ ] Commit Messages sind aussagekräftig

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119wkrZGkca8R8AiRTLd4GP

---
_Generated by [Claude Code](https://claude.ai/code/session_0119wkrZGkca8R8AiRTLd4GP)_