### PR TITLE
docs: CLAUDE.md um CI-Gate, offene Review-Punkte und PR #383 ergänzen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ feature/issue-XXX → testing → main (production)
 - **Vor Push:** lokale Tests (`npm test`); kein Merge bei CI-Fail
 - `main` ist protected
 
+### CI-Gate: PRs gegen `testing` laufen praktisch ohne CI (#381)
+
+Seit PR #381 triggern `ci-cd.yml` und `standards-audit.yml` nur noch bei `pull_request` gegen **`main`**. Auf einem PR Feature→`testing` läuft daher nur `mergeability` (plus CodeQL/Security-Scans) – **keine Unit-Tests, kein Lint, kein Build, kein E2E**. Der `push`-Trigger auf `testing` greift erst *nach* dem Merge.
+
+Praktische Konsequenzen:
+
+- **`npm test` und `npm run lint` lokal ausführen ist nicht optional**, sondern der einzige Gate vor `testing`. Grünes CI auf einem Feature-PR sagt nichts über die Tests aus.
+- Das erste echte CI-Gate ist der Release-PR `testing` → `main`. Regressionen fallen dort gebündelt auf, nicht mehr am einzelnen Feature-PR.
+- Beim Bewerten eines gemergten PRs nie aus „CI war grün" auf „Tests liefen" schließen – erst prüfen, *welche* Checks überhaupt getriggert wurden.
+
 ## Android-App (TWA)
 
 - Package: `com.sven4321.eisenhauer`
@@ -211,6 +221,16 @@ Der Backlog wurde am 2026-07-29 von 19 auf 7 offene Issues konsolidiert (erledig
 
 > **Wichtig für künftige Backlog-Updates:** Diese Tabelle listete zuvor mehrere längst geschlossene Issues (#263, #265, #256, #245). Vor dem Ergänzen bitte gegen die tatsächlich offenen Issues auf GitHub abgleichen, nicht blind fortschreiben.
 
+### Offene Punkte aus dem Review von PR #382 (2026-08-08)
+
+Beim Review des Release-PRs `testing` → `main` gefunden. Der blockierende Punkt (geleerte Felder landeten nicht in Firestore) ist mit PR #383 gefixt; die folgenden drei sind **noch nicht als GitHub-Issue erfasst** und daher hier festgehalten, damit sie nicht verloren gehen:
+
+1. **Bulk-Save ohne Offline-Queue** – `saveAllTasksToFirestore()` (`js/modules/storage.js`) committet direkt per `batch.commit()`, ohne `offlineQueue.add(...)`, Retry oder `ErrorHandler`. Der ersetzte Pfad über `saveTaskToFirestore` hatte all das (`maxRetries: 3`). Zusätzlich wird `saveAllTasks()` in `handleReorderTask()` (`script.js`) **weder awaited noch gecatcht** – ein fehlgeschlagener Bulk-Write ist damit komplett still, die UI zeigt die neue Reihenfolge trotzdem an. Der Performance-Gewinn aus #337 ist richtig, die Robustheit sollte nachgezogen werden.
+2. **Freistehende Notizen: kein Gast→Login-Pfad, nicht im Backup** – `loadAllNotes()` lädt bei angemeldeten Nutzern nur aus Firestore; ein Gegenstück zu `importGuestTasksToFirestore()` fehlt, sodass als Gast angelegte Notizen nach dem Anmelden unsichtbar sind (nicht zerstört – sie liegen weiter unter `eisenhauer-notes` in IndexedDB). Außerdem exportiert `exportData()` nur `tasks`, freistehende Notizen fehlen also im JSON-Backup. Task-Notizen sind als Task-Feld korrekt mit drin.
+3. **Kein Click-Suppress nach Long-Press** – `DragManager#handleTouchEnd()` wertet das Event nicht aus, und `preventDefault()` wird nur in `#handleTouchMove` gerufen. Long-Press ohne Bewegung → `#activateDragMode()` → Finger heben → der synthetische `click` erreicht den neuen Handler auf `.task-content` (`ui.js`) und öffnet ungewollt den Edit-Dialog. Bei echten Drags/Swipes mit Bewegung greift das `preventDefault()`.
+
+**Nebenbefund Versionsdrift:** `Android/app/build.gradle` steht auf `versionName "1.12.3"` / `versionCode 28` (Kommentar `// Match PWA version`), `package.json` auf `1.12.2`, `manifest.json` auf `1.12.1`. Der CI-Job „🔧 Version Checks" gibt die Werte nur aus und vergleicht sie **nicht** – er fängt solche Drifts also nicht ab.
+
 ### Backlog-Konsolidierung 2026-07-29
 
 Geschlossen und warum – damit nicht später erneut aufgemacht:
@@ -230,6 +250,7 @@ Geschlossen und warum – damit nicht später erneut aufgemacht:
 
 ### Kürzlich erledigt
 
+- **PR #383** – `updateTaskInFirestore()` löscht geleerte optionale Felder jetzt explizit per `deleteField()` (`completedAt`, `recurring`, `dueDate`, `category`; `notes` war seit PR #373 schon korrekt). Vorher blieb ein im Edit-Dialog geleertes Feld wegen `merge: true` in Firestore stehen und tauchte nach dem Reload wieder auf; `completedAt` verfälschte zusätzlich die Metriken. Nur der Firebase-Modus war betroffen. Gefunden beim Review von PR #382, siehe Abschnitt „Optionale Task-Felder löschen" oben
 - **PR #378** – Bestehende Aufgaben lassen sich per Klick auf den Task-Text im wiederverwendeten Quick-Add-Modal bearbeiten (Prefill + `updateTask()` statt neuer Aufgabe); siehe Abschnitt „Bestehende Aufgaben bearbeiten" oben
 - **#368** – `androidbrowserhelper` 2.5.0 → 2.7.2 angehoben, behebt Play-Console-Meldung zu deprecated Edge-to-Edge-APIs (`setStatusBarColor`/`setNavigationBarColor`) in der TWA-Library; kein eigener App-Code betroffen; siehe Abschnitt „Edge-to-Edge / Android 15 API-Deprecations" oben (PR #374, gemerged)
 - **#337** – `saveAllTasks()` nutzt jetzt `saveAllTasksToFirestore()` (Firestore `writeBatch`, gechunkt à 500 Ops) statt sequentieller Einzel-Writes; bestehende Storage-Exports unverändert importierbar, siehe Abschnitt „Performance: saveAllTasks() per Firestore-Batch" oben (PR #374, gemerged)


### PR DESCRIPTION
# Pull Request

## Beschreibung

Memory-Update nach dem Review von PR #382. Reine Dokumentation, kein Code.

**1. CI-Gate (#381) festhalten** — neuer Unterabschnitt unter „Branch-Strategie".

Seit PR #381 triggern `ci-cd.yml` und `standards-audit.yml` nur noch bei PRs gegen `main`. Auf einem PR Feature→`testing` läuft damit weder Unit-Test noch Lint, Build oder E2E — nur `mergeability` und die Security-Scans. Beobachtet an PR #383: dort lief genau **ein** Check.

Das stand nirgends und lädt zu einem konkreten Fehlschluss ein: „CI war grün" auf einem Feature-PR heißt nicht, dass die Tests liefen. Festgehalten sind deshalb die drei praktischen Konsequenzen — lokales `npm test` ist der einzige Gate vor `testing`, das erste echte CI-Gate ist der Release-PR gegen `main`, und beim Bewerten gemergter PRs erst prüfen, *welche* Checks überhaupt getriggert wurden.

**2. Offene Punkte aus dem Review von #382** — neuer Abschnitt unter „Offene Issues".

Drei Befunde ohne GitHub-Issue, mit Datei/Funktion und Reproduktionsweg, damit sie nicht verloren gehen:

- Bulk-Save (`saveAllTasksToFirestore`) ohne Offline-Queue, Retry und `ErrorHandler`, plus das ungecatchte `saveAllTasks()` im Reorder-Pfad — ein fehlgeschlagener Bulk-Write ist still.
- Freistehende Notizen: kein Gast→Login-Pfad (Gegenstück zu `importGuestTasksToFirestore()` fehlt) und nicht im JSON-Backup, da `exportData()` nur `tasks` schreibt.
- Kein Click-Suppress nach Long-Press ohne Bewegung → der synthetische `click` öffnet ungewollt den Edit-Dialog.

Dazu der Nebenbefund Versionsdrift (`build.gradle` 1.12.3/vc28 vs. `package.json` 1.12.2 vs. `manifest.json` 1.12.1) samt der Notiz, dass „🔧 Version Checks" die Werte nur ausgibt und nicht vergleicht.

**3. PR #383 unter „Kürzlich erledigt"** mit dem Kern des Bugs (`merge: true` + weggelassenes Feld) und dem Hinweis, dass nur der Firebase-Modus betroffen war.

Der `deleteField()`-Abschnitt selbst kam bereits mit PR #383 und ist hier unverändert.

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

Es ändert sich ausschließlich `CLAUDE.md`. Kein ausführbarer Code, keine Web-APIs, kein Android-Code.

## Testing Checklist

- [x] Lokaler Build erfolgreich
- [x] Keine TypeScript Errors
- [x] Keine neuen ESLint Warnings
- [x] App startet ohne Crashes
- [x] Geänderte Features funktionieren wie erwartet

Nur Doku — `npm test` und `npm run lint` sind gegenüber `testing` unverändert (12 Suites, 262 Tests; die 2 vorbestehenden Warnings in `update-version.js`). Prettier ist sauber.

## Screenshots / Videos

Keine — reine Textänderung an `CLAUDE.md`.

## Zusätzliche Notizen

Die drei Punkte unter „Offene Punkte aus dem Review von PR #382" sind bewusst **nur dokumentiert, nicht gefixt**. Sobald sie als GitHub-Issues erfasst sind, sollte der Abschnitt durch Issue-Nummern in der Backlog-Tabelle ersetzt werden — so wie es die Warnung direkt darüber für die Tabelle ohnehin verlangt (gegen die tatsächlich offenen Issues abgleichen, nicht blind fortschreiben).

## Reviewer Checklist

**Für den Reviewer:**

- [ ] Code folgt den Projekt-Konventionen
- [ ] Keine Web APIs ohne Platform-Check
- [ ] Keine Hard-coded Values (Config/Env Vars verwenden)
- [ ] Error Handling vorhanden
- [ ] Keine sensiblen Daten im Code
- [ ] Commit Messages sind aussagekräftig

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119wkrZGkca8R8AiRTLd4GP

---
_Generated by [Claude Code](https://claude.ai/code/session_0119wkrZGkca8R8AiRTLd4GP)_