### PR TITLE
Fix: Notizen-Feld-Styling und fehlenden Notes-Icon-Button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1161,6 +1161,61 @@ body.dark-mode .recurring-indicator:hover {
   color: #d1d5db;
 }
 
+/* Notes Task Icon Button */
+.notes-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
+  padding: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #d1d5db; /* Light gray - always visible */
+  opacity: 1;
+  transition:
+    opacity 0.2s ease,
+    transform 0.1s ease;
+  vertical-align: middle;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.notes-indicator:hover {
+  opacity: 0.7;
+  color: #9ca3af;
+}
+
+.notes-indicator:active {
+  transform: scale(0.9);
+}
+
+.notes-indicator svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.notes-indicator.has-notes {
+  color: var(--primary-color);
+}
+
+body.dark-mode .notes-indicator {
+  color: #9ca3af;
+}
+
+body.dark-mode .notes-indicator:hover {
+  color: #d1d5db;
+}
+
+body.dark-mode .notes-indicator.has-notes {
+  color: var(--primary-color);
+}
+
 /* Dark Mode: Ensure checkbox/radio labels are visible */
 body.dark-mode .recurring-option label,
 body.dark-mode .recurring-option span,
@@ -1630,6 +1685,30 @@ body.dark-mode .search-highlight {
 }
 
 .quick-add-input-wrapper input:focus {
+  outline: none;
+  border-color: var(--text-primary);
+}
+
+.quick-add-notes-row {
+  margin-bottom: 12px;
+}
+
+.quick-add-notes-input {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  background: var(--task-bg);
+  color: var(--text-primary);
+  resize: vertical;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.quick-add-notes-input:focus {
   outline: none;
   border-color: var(--text-primary);
 }


### PR DESCRIPTION
## Beschreibung

Behebt drei zusammenhängende Styling-Bugs rund um die Notizfunktion (Issue #371):

1. **Notizen-Feld zu klein:** `.quick-add-notes-input` (Quick-Add-Modal + Edit-Notes-Modal) hatte gar kein eigenes CSS und fiel auf die winzigen Browser-Defaults zurück. Neue Regel gibt dem Feld `min-height: 44px` – mindestens so groß wie das Titel-Eingabefeld.
2. **Notizen-Feld weiß statt Theme-Farbe:** Gleicher Grund (kein CSS) – Browser-Default-Hintergrund ist weiß. Jetzt `background: var(--task-bg)` / `color: var(--text-primary)`, analog zum Titel-Feld (`.quick-add-input-wrapper input`), inkl. korrektem Dark-Mode-Verhalten über die bestehenden CSS-Variablen.
3. **Seltsamer weißer Strich neben Aufgaben:** Der Notiz-Icon-Button (`.notes-indicator`, seit PR #373 in `ui.js` gerendert) hatte ebenfalls **kein** CSS. Als unstyled `<button>` mit undimensioniertem inline-SVG rendert das im Browser als dünner weißer Strich neben jedem Task-Titel. Neue `.notes-indicator`-Regeln (Größe, Farbe, Dark-Mode, `has-notes`-Zustand) analog zum bereits existierenden `.recurring-indicator`.

## Art der Änderung

- [x] Bugfix (non-breaking change)

## Testing Checklist

- [x] `npm test` lokal grün (222/222, `--exclude=tests/unit/storage.test.js`)
- [x] `npm run lint` lokal ohne neue Fehler/Warnungen
- [x] Reines CSS-only-Fix, keine JS/Markup-Änderungen

## Zusätzliche Notizen

Nur `style.css` geändert – keine neuen Klassen im Markup nötig, da `.quick-add-notes-input` (Quick-Add + Edit-Notes-Modal) und `.notes-indicator` (Task-Liste) bereits im HTML/JS vorhanden waren, nur ohne zugehöriges CSS.

---
_Generated by [Claude Code](https://claude.ai/code/session_011xqgf5S6QY2BB2AKNbxRGh)_