### PR TITLE
Fix robustness gaps from PR #382 review (Issue #385)

### DIFF
--- a/js/modules/drag-manager.js
+++ b/js/modules/drag-manager.js
@@ -87,6 +87,7 @@ export class DragManager {
     dragClone: null,
     dropTarget: null,
     originalOpacity: null,
+    suppressNextClick: false,
   };
 
   /**
@@ -151,6 +152,12 @@ export class DragManager {
 
     // Prevent context menu on long press
     this.element.addEventListener('contextmenu', (e) => e.preventDefault());
+
+    // Suppress the synthetic click a browser fires after touchend when a
+    // long-press activated drag mode but the finger never moved (so
+    // touchmove's preventDefault never ran). Capture phase so this runs
+    // before bubble-phase listeners on inner elements like .task-content.
+    this.element.addEventListener('click', this.#handleClickCapture.bind(this), true);
   }
 
   /**
@@ -172,6 +179,10 @@ export class DragManager {
    */
   #handleTouchStart(e) {
     const touch = e.touches[0];
+
+    // Reset from any previous gesture (e.g. a drag whose synthetic click
+    // never fired, so #handleClickCapture never got a chance to clear it)
+    this.state.suppressNextClick = false;
 
     // Store initial position
     this.state.startX = touch.clientX;
@@ -273,6 +284,19 @@ export class DragManager {
       this.element.style.transform = `translateX(${translateX}px)`;
       this.element.style.opacity = 1 - translateX / 300; // Fade out
     }
+  }
+
+  /**
+   * Consume the synthetic click following a suppressed touch gesture
+   * @private
+   * @param {MouseEvent} e
+   */
+  #handleClickCapture(e) {
+    if (!this.state.suppressNextClick) return;
+
+    this.state.suppressNextClick = false;
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   /**
@@ -392,6 +416,7 @@ export class DragManager {
    */
   #activateDragMode() {
     this.state.isDragging = true;
+    this.state.suppressNextClick = true;
 
     // Haptic feedback
     this.#triggerHaptic(50);

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -297,48 +297,74 @@ export async function saveAllTasksToFirestore(tasksBySegment, userId, db) {
   if (allTasks.length === 0) return;
 
   const BATCH_LIMIT = 500;
-
+  const chunks = [];
   for (let i = 0; i < allTasks.length; i += BATCH_LIMIT) {
-    const chunk = allTasks.slice(i, i + BATCH_LIMIT);
-    const batch = writeBatch(db);
+    chunks.push(allTasks.slice(i, i + BATCH_LIMIT));
+  }
 
-    chunk.forEach((task) => {
-      if (!task || typeof task.text !== 'string' || !task.segment) {
-        return;
-      }
+  // Add to offline queue with retry logic and error handling, same as the
+  // single-task write path — a bulk write is just as likely to hit a flaky
+  // connection, and it must not fail silently (Issue #385).
+  try {
+    await offlineQueue.add(
+      'saveAllTasks',
+      async () => {
+        for (const chunk of chunks) {
+          const batch = writeBatch(db);
 
-      const docRef = doc(collection(db, 'users', userId, 'tasks'), task.id.toString());
-      const taskData = {
-        text: task.text,
-        segment: task.segment,
-        checked: task.checked || false,
-        createdAt: task.createdAt || serverTimestamp(),
-      };
+          chunk.forEach((task) => {
+            if (!task || typeof task.text !== 'string' || !task.segment) {
+              return;
+            }
 
-      if (task.completedAt) {
-        taskData.completedAt = task.completedAt;
-      }
+            const docRef = doc(collection(db, 'users', userId, 'tasks'), task.id.toString());
+            const taskData = {
+              text: task.text,
+              segment: task.segment,
+              checked: task.checked || false,
+              createdAt: task.createdAt || serverTimestamp(),
+            };
 
-      if (task.recurring) {
-        taskData.recurring = task.recurring;
-      }
+            if (task.completedAt) {
+              taskData.completedAt = task.completedAt;
+            }
 
-      if (task.dueDate) {
-        taskData.dueDate = task.dueDate;
-      }
+            if (task.recurring) {
+              taskData.recurring = task.recurring;
+            }
 
-      if (task.category) {
-        taskData.category = task.category;
-      }
+            if (task.dueDate) {
+              taskData.dueDate = task.dueDate;
+            }
 
-      if (task.notes) {
-        taskData.notes = task.notes;
-      }
+            if (task.category) {
+              taskData.category = task.category;
+            }
 
-      batch.set(docRef, taskData);
+            if (task.notes) {
+              taskData.notes = task.notes;
+            }
+
+            batch.set(docRef, taskData);
+          });
+
+          await batch.commit();
+        }
+      },
+      {
+        userId,
+        taskCount: allTasks.length,
+      },
+      3 // maxRetries
+    );
+  } catch (error) {
+    // Graceful degradation: Continue with local storage only
+    console.warn('Firebase bulk save failed, continuing with local storage:', error);
+    ErrorHandler.handleStorageError(error, {
+      operation: 'saveAllTasksToFirestore',
+      data: { taskCount: allTasks.length },
+      silent: false,
     });
-
-    await batch.commit();
   }
 }
 
@@ -644,15 +670,76 @@ export async function importGuestTasksToFirestore(userId, db) {
 }
 
 /**
+ * Import guest notes to user account (explicit user action)
+ * Mirrors importGuestTasksToFirestore — without this, standalone notes
+ * created as a guest silently stay invisible after signing in (Issue #385).
+ * @param {string} userId - User ID
+ * @param {object} db - Firestore database instance
+ * @returns {object} { success, noteCount, error }
+ */
+export async function importGuestNotesToFirestore(userId, db) {
+  try {
+    const guestNotes = await loadGuestNotes();
+
+    if (!guestNotes || guestNotes.length === 0) {
+      return {
+        success: false,
+        noteCount: 0,
+        error: 'Keine Gast-Notizen zum Importieren gefunden',
+      };
+    }
+
+    const batch = writeBatch(db);
+    let importedCount = 0;
+
+    guestNotes.forEach((note) => {
+      if (!note || typeof note.text !== 'string') return;
+
+      const docRef = doc(collection(db, 'users', userId, 'notes'), note.id.toString());
+      const noteData = {
+        text: note.text,
+        createdAt: note.createdAt || serverTimestamp(),
+      };
+
+      if (note.sourceTaskId) {
+        noteData.sourceTaskId = note.sourceTaskId;
+      }
+
+      batch.set(docRef, noteData);
+      importedCount++;
+    });
+
+    await batch.commit();
+
+    // Delete guest notes after successful import
+    await localforage.removeItem(STORAGE_KEYS.NOTES);
+
+    return {
+      success: true,
+      noteCount: importedCount,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      noteCount: 0,
+      error: error.message || 'Fehler beim Importieren der Gast-Notizen',
+    };
+  }
+}
+
+/**
  * Export data as JSON file
  * @param {object} tasks - Tasks object
  * @param {string} version - App version
+ * @param {Array} [notes] - Standalone notes (Issue #385: previously missing from backup)
  */
-export function exportData(tasks, version) {
+export function exportData(tasks, version, notes = []) {
   const exportData = {
     version: version || 'unknown',
     exportDate: new Date().toISOString(),
     tasks: tasks,
+    notes: notes,
   };
 
   const dataStr = JSON.stringify(exportData, null, 2);
@@ -673,10 +760,13 @@ export function exportData(tasks, version) {
  * Import data from JSON file
  * @param {File} file - File to import
  * @param {object} currentTasks - Current tasks object
- * @param {function} saveCallback - Callback to save imported tasks
+ * @param {function} saveCallback - Callback to save imported tasks; called with
+ *   (finalTasks, finalNotes) when the backup contains standalone notes (Issue #385),
+ *   or (finalTasks) alone otherwise, to keep older callers unaffected.
+ * @param {Array} [currentNotes] - Current standalone notes, for merging
  * @returns {Promise<object>} Imported tasks object
  */
-export function importData(file, currentTasks, saveCallback) {
+export function importData(file, currentTasks, saveCallback, currentNotes = []) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
 
@@ -689,7 +779,9 @@ export function importData(file, currentTasks, saveCallback) {
           throw new Error('Ungültiges Datenformat: Keine Tasks gefunden');
         }
 
+        const hasImportedNotes = Array.isArray(importedData.notes);
         let finalTasks;
+        let finalNotes;
 
         if (
           confirm(
@@ -710,14 +802,29 @@ export function importData(file, currentTasks, saveCallback) {
               finalTasks[segmentId].push(task);
             });
           });
+
+          if (hasImportedNotes) {
+            finalNotes = [...currentNotes];
+            importedData.notes.forEach((note) => {
+              // Generate new ID to avoid conflicts, same as tasks above
+              finalNotes.push({ ...note, id: Date.now() + Math.random() });
+            });
+          }
         } else {
           // Replace: Overwrite existing tasks
           finalTasks = importedData.tasks;
+          if (hasImportedNotes) {
+            finalNotes = importedData.notes;
+          }
         }
 
         // Call save callback if provided
         if (saveCallback) {
-          await saveCallback(finalTasks);
+          if (hasImportedNotes) {
+            await saveCallback(finalTasks, finalNotes);
+          } else {
+            await saveCallback(finalTasks);
+          }
         }
         resolve(finalTasks);
       } catch (error) {

--- a/script.js
+++ b/script.js
@@ -82,6 +82,7 @@ import {
   requestPersistentStorage,
   getSyncStatus,
   importGuestTasksToFirestore,
+  importGuestNotesToFirestore,
 } from './js/modules/storage.js';
 import {
   renderAllTasks,
@@ -104,6 +105,7 @@ import { exportCsv, exportMarkdown } from './js/modules/export.js';
 import { suggestSegment, SEGMENT_SUGGEST_LABELS } from './js/modules/smart-suggest.js';
 import { showWarning, showError, showSuccess } from './js/modules/notifications.js';
 import { showUndoDelete, showUndoToggle } from './js/modules/undo.js';
+import { ErrorHandler } from './js/modules/error-handler.js';
 import {
   isSupported as remindersSupported,
   requestPermission as requestReminderPermission,
@@ -430,7 +432,13 @@ function handleReorderTask(taskId, segment, direction) {
     if (currentUser && db && !isGuestMode) {
       // In authenticated mode, save all tasks in the segment
       // (Firestore doesn't have ordering, so we save the entire array)
-      saveAllTasks();
+      saveAllTasks().catch((error) => {
+        ErrorHandler.handleStorageError(error, {
+          operation: 'saveAllTasks',
+          data: { segment },
+          silent: false,
+        });
+      });
     } else {
       // Save to LocalForage (guest mode)
       saveGuestTasks(tasks);
@@ -996,11 +1004,22 @@ function setupEventListeners() {
     });
   }
 
+  // Persist an imported/merged notes array (Issue #385: notes were missing
+  // from the JSON backup entirely, so a restore could never bring them back)
+  const saveImportedNotes = async (notesArray) => {
+    setAllNotesState(notesArray);
+    if (currentUser && db && !isGuestMode) {
+      await Promise.all(notesArray.map((note) => saveNoteToFirestore(note, currentUser.uid, db)));
+    } else {
+      await saveGuestNotes(notesArray);
+    }
+  };
+
   // Export button
   const exportBtn = document.getElementById('exportBtn');
   if (exportBtn) {
     exportBtn.addEventListener('click', () => {
-      exportData(tasks, APP_VERSION);
+      exportData(tasks, APP_VERSION, getAllNotes());
     });
   }
 
@@ -1011,12 +1030,20 @@ function setupEventListeners() {
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', (e) => {
       if (e.target.files.length > 0) {
-        importData(e.target.files[0], tasks, async (importedTasks) => {
-          setAllTasks(importedTasks);
-          await saveAllTasks();
-          renderTasksWithCallbacks();
-          alert(getTranslation('importSuccess') || 'Data imported successfully!');
-        });
+        importData(
+          e.target.files[0],
+          tasks,
+          async (importedTasks, importedNotes) => {
+            setAllTasks(importedTasks);
+            await saveAllTasks();
+            if (importedNotes) {
+              await saveImportedNotes(importedNotes);
+            }
+            renderTasksWithCallbacks();
+            alert(getTranslation('importSuccess') || 'Data imported successfully!');
+          },
+          getAllNotes()
+        );
       }
     });
   }
@@ -1025,7 +1052,7 @@ function setupEventListeners() {
   const exportJsonBtn = document.getElementById('exportJsonBtn');
   if (exportJsonBtn) {
     exportJsonBtn.addEventListener('click', () => {
-      exportData(tasks, APP_VERSION);
+      exportData(tasks, APP_VERSION, getAllNotes());
     });
   }
 
@@ -1119,38 +1146,54 @@ function setupEventListeners() {
         return;
       }
 
-      // Count guest tasks first
+      // Count guest tasks and standalone notes first (Issue #385: notes had no
+      // guest→login migration path at all, unlike tasks)
       const guestTasks = await loadGuestTasks();
       let guestTaskCount = 0;
       Object.keys(guestTasks).forEach((segmentId) => {
         guestTaskCount += guestTasks[segmentId].length;
       });
 
-      if (guestTaskCount === 0) {
-        showWarning('Keine Gast-Tasks zum Importieren gefunden');
+      const guestNotes = await loadGuestNotes();
+      const guestNoteCount = guestNotes.length;
+
+      if (guestTaskCount === 0 && guestNoteCount === 0) {
+        showWarning('Keine Gast-Daten zum Importieren gefunden');
         return;
       }
 
       // Show confirmation dialog
+      const parts = [];
+      if (guestTaskCount > 0) parts.push(`${guestTaskCount} Gast-Tasks`);
+      if (guestNoteCount > 0) parts.push(`${guestNoteCount} Gast-Notizen`);
       const confirmed = confirm(
-        `Du hast ${guestTaskCount} Gast-Tasks.\n\nMöchtest du diese in deinen Account importieren?\n\nDie Gast-Daten werden nach dem Import gelöscht.`
+        `Du hast ${parts.join(' und ')}.\n\nMöchtest du diese in deinen Account importieren?\n\nDie Gast-Daten werden nach dem Import gelöscht.`
       );
 
       if (!confirmed) return;
 
-      // Perform import
-      const result = await window.importGuestTasksToFirestore(currentUser.uid, db);
+      // Perform import (independently, so a notes failure doesn't hide a
+      // successful task import or vice versa)
+      const taskResult =
+        guestTaskCount > 0
+          ? await window.importGuestTasksToFirestore(currentUser.uid, db)
+          : { success: true, taskCount: 0 };
+      const noteResult =
+        guestNoteCount > 0
+          ? await importGuestNotesToFirestore(currentUser.uid, db)
+          : { success: true, noteCount: 0 };
 
-      if (result.success) {
+      if (taskResult.success && noteResult.success) {
         showSuccess(
-          `${result.taskCount} Gast-Tasks erfolgreich importiert! Seite wird neu geladen...`
+          `${taskResult.taskCount} Gast-Tasks und ${noteResult.noteCount} Gast-Notizen erfolgreich importiert! Seite wird neu geladen...`
         );
         // Reload tasks and close modal
         setTimeout(() => {
           location.reload();
         }, 1500);
       } else {
-        showError(`Import fehlgeschlagen: ${result.error}`);
+        const errors = [taskResult.error, noteResult.error].filter(Boolean).join('; ');
+        showError(`Import fehlgeschlagen: ${errors}`);
       }
     });
   }


### PR DESCRIPTION
## Beschreibung

Setzt die drei offenen Punkte aus Issue #385 um (gefunden beim Review von Release-PR #382; der blockierende Fund daraus wurde bereits separat in PR #383 gefixt):

1. **Bulk-Save ohne Offline-Queue/Retry/Fehlerbehandlung** — `saveAllTasksToFirestore()` (`js/modules/storage.js`) committet jetzt über `offlineQueue.add(...)` mit Retry-Logik und `ErrorHandler.handleStorageError`, analog zum bestehenden Einzel-Task-Pfad. Der bislang weder awaited noch gecatchte Aufruf in `handleReorderTask()` (`script.js`) hat jetzt ein `.catch()`.
2. **Freistehende Notizen: kein Gast→Login-Pfad, fehlen im Backup** — Neue `importGuestNotesToFirestore()` (analog zu `importGuestTasksToFirestore()`), verdrahtet in den bestehenden „Gast-Daten importieren"-Button in `script.js` (importiert jetzt Tasks *und* Notizen). `exportData()`/`importData()` nehmen jetzt einen optionalen `notes`-Parameter, sodass das JSON-Backup/-Restore Notizen nicht mehr stillschweigend verliert. Bestehende Aufrufer bleiben kompatibel (`notes` defaultet auf `[]`, `saveCallback` bekommt nur dann einen zweiten Parameter, wenn das Backup Notizen enthält).
3. **Kein Click-Suppress nach Long-Press ohne Bewegung** — `DragManager` (`js/modules/drag-manager.js`) merkt sich jetzt beim Aktivieren des Drag-Modus, dass der nächste synthetische `click` (der ohne Fingerbewegung nie durch `touchmove`s `preventDefault()` unterdrückt wird) konsumiert werden muss, und stoppt ihn per Capture-Listener bevor er den Edit-Dialog aus PR #378 öffnet.

Der in #385 dokumentierte Nebenbefund zur Versionsdrift ist nicht Teil dieses PRs (laut Issue kein eigener Fix-Punkt).

## Art der Änderung

- [x] Bugfix (non-breaking change)

## Testing Checklist

- [x] `npm test` lokal grün (262 Tests, inkl. `tests/unit/storage.test.js` mit gemocktem Firestore)
- [x] `npm run lint` sauber (keine neuen Warnungen)
- [ ] Manuell in Browser getestet (nicht möglich in dieser Remote-Umgebung ohne laufenden Dev-Server/Touch-Gerät für den Long-Press-Fall)

## Zusätzliche Notizen

Kein plattformspezifischer Code betroffen (reines PWA/JS, kein Android-Code).

Closes #385.


---
_Generated by [Claude Code](https://claude.ai/code/session_015NSRfCfzWNXe3r8oxRogBT)_